### PR TITLE
feat: introduce annotation-based routing system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ repositories { mavenCentral() }
     dependencies {
         // Spring Boot
         implementation 'org.springframework.boot:spring-boot-starter'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
         // Playwright
@@ -28,6 +29,8 @@ repositories { mavenCentral() }
     // JUnit 5
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+
+    implementation 'org.assertj:assertj-core'
 
     // Allure
     testImplementation 'io.qameta.allure:allure-junit5:2.29.0'

--- a/src/main/java/com/example/testsupport/framework/api/CasinoApiClient.java
+++ b/src/main/java/com/example/testsupport/framework/api/CasinoApiClient.java
@@ -1,0 +1,60 @@
+package com.example.testsupport.framework.api;
+
+import com.example.testsupport.config.AppProperties;
+import com.example.testsupport.framework.api.dto.Brand;
+import com.example.testsupport.framework.api.dto.Category;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Simple HTTP client for retrieving casino data used in routing.
+ */
+@Component
+public class CasinoApiClient {
+    private final RestTemplate restTemplate;
+    private final AppProperties props;
+
+    public CasinoApiClient(RestTemplateBuilder builder, AppProperties props) {
+        this.restTemplate = builder.build();
+        this.props = props;
+    }
+
+    private String apiBaseUrl() {
+        // In real life this would be a dedicated API host
+        return props.getBaseUrl() + "/api";
+    }
+
+    public List<Brand> fetchBrands() {
+        try {
+            ResponseEntity<List<Brand>> response = restTemplate.exchange(
+                    apiBaseUrl() + "/brands",
+                    HttpMethod.GET,
+                    null,
+                    new ParameterizedTypeReference<>() {}
+            );
+            return response.getBody();
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
+
+    public List<Category> fetchCategories() {
+        try {
+            ResponseEntity<List<Category>> response = restTemplate.exchange(
+                    apiBaseUrl() + "/categories",
+                    HttpMethod.GET,
+                    null,
+                    new ParameterizedTypeReference<>() {}
+            );
+            return response.getBody();
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/api/dto/Brand.java
+++ b/src/main/java/com/example/testsupport/framework/api/dto/Brand.java
@@ -1,0 +1,36 @@
+package com.example.testsupport.framework.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * DTO representing a casino brand returned by the backend API.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Brand {
+    private String name;
+    private String alias;
+
+    public Brand() {
+    }
+
+    public Brand(String name, String alias) {
+        this.name = name;
+        this.alias = alias;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/api/dto/Category.java
+++ b/src/main/java/com/example/testsupport/framework/api/dto/Category.java
@@ -1,0 +1,36 @@
+package com.example.testsupport.framework.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * DTO representing a casino category returned by the backend API.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Category {
+    private String name;
+    private String alias;
+
+    public Category() {
+    }
+
+    public Category(String name, String alias) {
+        this.name = name;
+        this.alias = alias;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/data/CasinoDataRegistry.java
+++ b/src/main/java/com/example/testsupport/framework/data/CasinoDataRegistry.java
@@ -1,0 +1,40 @@
+package com.example.testsupport.framework.data;
+
+import com.example.testsupport.framework.api.CasinoApiClient;
+import com.example.testsupport.framework.api.dto.Brand;
+import com.example.testsupport.framework.api.dto.Category;
+import jakarta.annotation.PostConstruct;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+/**
+ * Loads and caches casino-related data such as brands and categories.
+ */
+@Component
+public class CasinoDataRegistry {
+    private final CasinoApiClient apiClient;
+    private Map<String, String> brandAliases = Collections.emptyMap();
+    private Map<String, String> categoryAliases = Collections.emptyMap();
+
+    public CasinoDataRegistry(CasinoApiClient apiClient) {
+        this.apiClient = apiClient;
+    }
+
+    @PostConstruct
+    public void init() {
+        brandAliases = apiClient.fetchBrands().stream()
+                .collect(Collectors.toMap(Brand::getName, Brand::getAlias));
+        categoryAliases = apiClient.fetchCategories().stream()
+                .collect(Collectors.toMap(Category::getName, Category::getAlias));
+    }
+
+    public String getBrandAliasByName(String name) {
+        return brandAliases.get(name);
+    }
+
+    public String getCategoryAliasByName(String name) {
+        return categoryAliases.get(name);
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/routing/PageAsserter.java
+++ b/src/main/java/com/example/testsupport/framework/routing/PageAsserter.java
@@ -1,0 +1,71 @@
+package com.example.testsupport.framework.routing;
+
+import com.microsoft.playwright.Page;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.assertj.core.api.Assertions;
+import org.springframework.stereotype.Component;
+
+/**
+ * Сервис для проверки, что браузер находится на ожидаемой странице.
+ */
+@Component
+public class PageAsserter {
+    private final Page page;
+    private final UrlBuilder urlBuilder;
+
+    public PageAsserter(Page page, UrlBuilder urlBuilder) {
+        this.page = page;
+        this.urlBuilder = urlBuilder;
+    }
+
+    /**
+     * Проверяет, что текущий URL соответствует URL указанного Page Object.
+     *
+     * @param pageClass класс PO, помеченный {@link PagePath}
+     */
+    public void amOn(Class<?> pageClass) {
+        String expectedUrl = urlBuilder.getPageUrl(pageClass);
+        page.waitForURL(url -> url.startsWith(expectedUrl));
+        Assertions.assertThat(page.url())
+                .withFailMessage("Ожидали быть на странице %s (%s), но оказались на %s",
+                        pageClass.getSimpleName(), expectedUrl, page.url())
+                .startsWith(expectedUrl);
+    }
+
+    /** Проверяет наличие ключа query-параметра. */
+    public void urlContainsKey(String key) {
+        Assertions.assertThat(getQueryParams()).containsKey(key);
+    }
+
+    /** Проверяет наличие пары ключ-значение среди query-параметров. */
+    public void urlContainsQueryParam(String key, String value) {
+        Assertions.assertThat(getQueryParams()).containsEntry(key, value);
+    }
+
+    /** Проверяет, что URL содержит все указанные query-параметры. */
+    public void urlContainsQueryParams(Map<String, String> params) {
+        Assertions.assertThat(getQueryParams()).containsAllEntriesOf(params);
+    }
+
+    private Map<String, String> getQueryParams() {
+        String query = URI.create(page.url()).getRawQuery();
+        if (query == null || query.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return Arrays.stream(query.split("&"))
+                .map(p -> p.split("=", 2))
+                .collect(Collectors.toMap(
+                        p -> decode(p[0]),
+                        p -> p.length > 1 ? decode(p[1]) : ""));
+    }
+
+    private String decode(String value) {
+        return URLDecoder.decode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/routing/PagePath.java
+++ b/src/main/java/com/example/testsupport/framework/routing/PagePath.java
@@ -1,0 +1,20 @@
+package com.example.testsupport.framework.routing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Аннотация для указания относительного пути к странице.
+ * Используется системой роутинга для построения полных URL.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface PagePath {
+    /**
+     * Относительный путь к странице.
+     * @return например, "/casino"
+     */
+    String value();
+}

--- a/src/main/java/com/example/testsupport/framework/routing/UrlBuilder.java
+++ b/src/main/java/com/example/testsupport/framework/routing/UrlBuilder.java
@@ -1,0 +1,79 @@
+package com.example.testsupport.framework.routing;
+
+import com.example.testsupport.config.AppProperties;
+import com.example.testsupport.framework.localization.LocalizationService;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+/**
+ * Сервис для построения URL-адресов страниц с учетом текущего языка.
+ * Является единым источником правды для генерации URL.
+ */
+@Component
+public class UrlBuilder {
+    private final AppProperties props;
+    private final LocalizationService ls;
+
+    public UrlBuilder(AppProperties props, LocalizationService ls) {
+        this.props = props;
+        this.ls = ls;
+    }
+
+    /**
+     * Возвращает базовый URL для текущего языка (с префиксом или без).
+     * @return Например, "https://spelet.lv" или "https://spelet.lv/ru"
+     */
+    public String getBaseUrl() {
+        String currentLang = ls.getCurrentLangCode();
+        String defaultLang = props.getDefaultLanguage();
+
+        if (currentLang != null && currentLang.equalsIgnoreCase(defaultLang)) {
+            return props.getBaseUrl();
+        }
+        return props.getBaseUrl() + "/" + currentLang;
+    }
+
+    /**
+     * Возвращает полный URL для класса страницы, помеченного аннотацией {@link PagePath},
+     * дополняя его указанными query-параметрами.
+     *
+     * @param pageClass   класс Page Object (например, {@code CasinoPage.class})
+     * @param queryParams карта query-параметров. Может быть {@code null} или пустой.
+     * @return полный URL для этой страницы с учетом языка и переданных параметров
+     */
+    public String getPageUrl(Class<?> pageClass, Map<String, String> queryParams) {
+        PagePath pathAnnotation = pageClass.getAnnotation(PagePath.class);
+        if (pathAnnotation == null) {
+            throw new IllegalArgumentException(
+                "Класс " + pageClass.getSimpleName() + " не имеет аннотации @PagePath");
+        }
+        String path = Objects.requireNonNull(pathAnnotation.value(),
+                "Path in @PagePath cannot be null");
+        String url = getBaseUrl() + path;
+
+        Map<String, String> params = queryParams == null ? Collections.emptyMap() : queryParams;
+        if (params.isEmpty()) {
+            return url;
+        }
+        String query = params.entrySet().stream()
+                .map(e -> encode(e.getKey()) + "=" + encode(e.getValue()))
+                .collect(Collectors.joining("&"));
+        return url + "?" + query;
+    }
+
+    /**
+     * Возвращает URL для указанного класса без дополнительных параметров.
+     */
+    public String getPageUrl(Class<?> pageClass) {
+        return getPageUrl(pageClass, Collections.emptyMap());
+    }
+
+    private String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/com/example/testsupport/ui/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/ui/pages/CasinoPage.java
@@ -1,0 +1,23 @@
+package com.example.testsupport.ui.pages;
+
+import com.example.testsupport.framework.routing.PagePath;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@PagePath("/casino")
+@Component
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+public class CasinoPage {
+    private final Page page;
+
+    public CasinoPage(Page page) {
+        this.page = page;
+    }
+
+    public Locator pageTitle() {
+        return page.locator("h1.page-title");
+    }
+}

--- a/src/test/java/com/example/testsupport/ui/pages/MainPage.java
+++ b/src/test/java/com/example/testsupport/ui/pages/MainPage.java
@@ -1,14 +1,16 @@
-package com.example.testsupport.pages;
+package com.example.testsupport.ui.pages;
 
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 import com.example.testsupport.framework.localization.LocalizationService;
+import com.example.testsupport.framework.routing.PagePath;
 
+@PagePath("/")
 @Component
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class MainPage {
@@ -36,9 +38,12 @@ public class MainPage {
 
     /**
      * Переходит на страницу казино через меню.
+     *
+     * @return объект {@link CasinoPage} после навигации
      */
-    public void clickCasino() {
+    public CasinoPage clickCasino() {
         page.waitForNavigation(() -> casinoLink().click());
+        return new CasinoPage(page);
     }
 
     /**
@@ -48,11 +53,19 @@ public class MainPage {
      * @return текущий объект {@link MainPage}
      */
     public MainPage verifyUrlContains(String expectedPath) {
-        String current = page.url();
-        Assertions.assertTrue(
-                current.contains(expectedPath),
-                String.format("Ожидалось, что URL содержит '%s', но фактический URL '%s'", expectedPath, current)
-        );
+        Assertions.assertThat(page.url()).contains(expectedPath);
+        return this;
+    }
+
+    /**
+     * Проверяет, что текущий URL равен ожидаемому URL.
+     *
+     * @param expectedUrl полный ожидаемый URL
+     * @return текущий объект {@link MainPage}
+     */
+    public MainPage verifyUrlIs(String expectedUrl) {
+        page.waitForURL(expectedUrl);
+        Assertions.assertThat(page.url()).isEqualTo(expectedUrl);
         return this;
     }
 }

--- a/src/test/java/tests/AnnotationNavigationTest.java
+++ b/src/test/java/tests/AnnotationNavigationTest.java
@@ -1,0 +1,43 @@
+package tests;
+
+import com.example.testsupport.TestApplication;
+import com.example.testsupport.framework.browser.PlaywrightManager;
+import com.example.testsupport.framework.listeners.PlaywrightExtension;
+import com.example.testsupport.framework.routing.PageAsserter;
+import com.example.testsupport.ui.pages.CasinoPage;
+import com.example.testsupport.ui.pages.MainPage;
+import io.qameta.allure.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static io.qameta.allure.Allure.step;
+
+@SpringBootTest(classes = TestApplication.class)
+@ExtendWith(PlaywrightExtension.class)
+@Epic("Spelet.lv")
+@Feature("Роутинг через аннотации")
+class AnnotationNavigationTest {
+
+    @Autowired private PlaywrightManager playwrightManager;
+    @Autowired private MainPage mainPage;
+    @Autowired private PageAsserter asserter;
+
+    @Test
+    @DisplayName("Переход с главной страницы на страницу казино")
+    void navigationFromMainToCasinoPage() {
+        step("Открыть главную страницу", () ->
+            playwrightManager.open(MainPage.class)
+        );
+
+        step("Перейти на страницу казино через меню", () ->
+            mainPage.clickCasino()
+        );
+
+        step("Проверить, что мы находимся на странице казино", () ->
+            asserter.amOn(CasinoPage.class)
+        );
+    }
+}

--- a/src/test/java/tests/FilterTest.java
+++ b/src/test/java/tests/FilterTest.java
@@ -1,0 +1,47 @@
+package tests;
+
+import com.example.testsupport.TestApplication;
+import com.example.testsupport.framework.browser.PlaywrightManager;
+import com.example.testsupport.framework.data.CasinoDataRegistry;
+import com.example.testsupport.framework.listeners.PlaywrightExtension;
+import com.example.testsupport.framework.routing.PageAsserter;
+import com.example.testsupport.ui.pages.CasinoPage;
+import io.qameta.allure.*;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static io.qameta.allure.Allure.step;
+
+/**
+ * Пример теста, демонстрирующего использование DataRegistry и PageAsserter
+ * для построения и проверки URL без хардкода алиасов.
+ */
+@SpringBootTest(classes = TestApplication.class)
+@ExtendWith(PlaywrightExtension.class)
+@Epic("Spelet.lv")
+@Feature("Фильтрация казино")
+class FilterTest {
+
+    @Autowired private PlaywrightManager playwrightManager;
+    @Autowired private CasinoDataRegistry registry;
+    @Autowired private PageAsserter asserter;
+
+    @Test
+    @DisplayName("Открытие страницы казино с фильтром по бренду")
+    void openCasinoPageWithBrandFilter() {
+        String alias = step("Получить алиас бренда из API",
+                () -> registry.getBrandAliasByName("Some Brand"));
+
+        step("Открыть страницу казино с query-параметром",
+                () -> playwrightManager.open(CasinoPage.class, Map.of("brand", alias)));
+
+        step("Проверить URL и наличие параметра", () -> {
+            asserter.amOn(CasinoPage.class);
+            asserter.urlContainsQueryParam("brand", alias);
+        });
+    }
+}

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -4,8 +4,9 @@ import com.example.testsupport.TestApplication;
 import com.example.testsupport.config.AppProperties;
 import com.example.testsupport.framework.browser.PlaywrightManager;
 import com.example.testsupport.framework.listeners.PlaywrightExtension;
-import com.example.testsupport.framework.localization.LocalizationService;
-import com.example.testsupport.pages.MainPage;
+import com.example.testsupport.framework.routing.PageAsserter;
+import com.example.testsupport.ui.pages.CasinoPage;
+import com.example.testsupport.ui.pages.MainPage;
 import io.qameta.allure.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,7 +35,7 @@ class MultilingualNavigationTest {
     private AppProperties props;
 
     @Autowired
-    private LocalizationService ls;
+    private PageAsserter asserter;
 
     static Stream<String> languageProvider() {
         return Stream.of("lv", "ru", "en");
@@ -45,18 +46,13 @@ class MultilingualNavigationTest {
     @ParameterizedTest(name = "[Язык: {0}]")
     @MethodSource("languageProvider")
     void navigateToCasinoPageOnAllLanguages(String languageCode) {
-        step("Установить язык теста: " + languageCode, () -> {
-            props.setLanguage(languageCode);
-            ls.loadLocale(languageCode);
-        });
+        step("Установить язык теста: " + languageCode,
+                () -> props.setLanguage(languageCode));
 
-        step("Открыть главную страницу", () -> playwrightManager.open());
+        step("Открыть главную страницу", () -> playwrightManager.open(MainPage.class));
         step("Переход на страницу казино", mainPage::clickCasino);
 
-        String expectedPath = languageCode.equals(props.getDefaultLanguage())
-                ? "/casino"
-                : "/" + languageCode + "/casino";
-        step("Проверить, что URL содержит " + expectedPath,
-                () -> mainPage.verifyUrlContains(expectedPath));
+        step("Проверить, что мы находимся на странице казино",
+                () -> asserter.amOn(CasinoPage.class));
     }
 }


### PR DESCRIPTION
## Summary
- add @PagePath annotation and smarter UrlBuilder for class-based URLs
- navigate via PlaywrightManager.open(Class) and verify location with PageAsserter
- annotate MainPage and new CasinoPage, with tests demonstrating annotation-driven routing
- add CasinoApiClient and CasinoDataRegistry for API-backed aliases
- support query params in UrlBuilder and PageAsserter with new FilterTest

## Testing
- `gradle test` *(fails: Failed to download Chromium 130.0.6723.31)*
- `gradle compileTestJava`


------
https://chatgpt.com/codex/tasks/task_e_68a6eb712198832fa3b3cea3f64f8982