### PR TITLE
feat: add lifecycle strategies for Playwright

### DIFF
--- a/src/test/java/com/example/testsupport/framework/lifecycle/BrowserStackPlaywrightLifecycle.java
+++ b/src/test/java/com/example/testsupport/framework/lifecycle/BrowserStackPlaywrightLifecycle.java
@@ -1,0 +1,45 @@
+package com.example.testsupport.framework.lifecycle;
+
+import com.example.testsupport.framework.browser.PlaywrightManager;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * Стратегия жизненного цикла для запуска в BrowserStack.
+ * Для каждого теста создаётся отдельная сессия BrowserStack.
+ */
+@Component
+@Profile("browserstack")
+public class BrowserStackPlaywrightLifecycle implements PlaywrightLifecycleStrategy {
+
+    private final PlaywrightManager manager;
+
+    public BrowserStackPlaywrightLifecycle(PlaywrightManager manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        System.setProperty("bs.name", context.getDisplayName());
+        manager.initializeBrowser();
+        manager.createContextAndPage();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        String status = context.getExecutionException().isPresent() ? "failed" : "passed";
+        String reason = context.getExecutionException().map(Throwable::getMessage).orElse("");
+        try {
+            manager.getPage().evaluate(
+                    "({status,reason}) => window.browserstack_executor({action: 'setSessionStatus', arguments: {status, reason}})",
+                    Map.of("status", status, "reason", reason));
+        } catch (RuntimeException ignored) {
+            // Игнорируем сбои при установке статуса, чтобы не скрыть основную ошибку теста
+        }
+        manager.closeAll();
+    }
+}
+

--- a/src/test/java/com/example/testsupport/framework/lifecycle/LocalPlaywrightLifecycle.java
+++ b/src/test/java/com/example/testsupport/framework/lifecycle/LocalPlaywrightLifecycle.java
@@ -1,0 +1,42 @@
+package com.example.testsupport.framework.lifecycle;
+
+import com.example.testsupport.framework.browser.PlaywrightManager;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * Стратегия жизненного цикла для локального запуска.
+ * Инициализирует браузер один раз на класс и создаёт новый контекст для каждого теста.
+ */
+@Component
+@Profile("local")
+public class LocalPlaywrightLifecycle implements PlaywrightLifecycleStrategy {
+
+    private final PlaywrightManager manager;
+
+    public LocalPlaywrightLifecycle(PlaywrightManager manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        manager.initializeBrowser();
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        manager.createContextAndPage();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        manager.closeContext();
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        manager.closeBrowser();
+    }
+}
+

--- a/src/test/java/com/example/testsupport/framework/lifecycle/PlaywrightLifecycleStrategy.java
+++ b/src/test/java/com/example/testsupport/framework/lifecycle/PlaywrightLifecycleStrategy.java
@@ -1,0 +1,23 @@
+package com.example.testsupport.framework.lifecycle;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Стратегия управления жизненным циклом Playwright.
+ * В зависимости от активного профиля Spring будет выбрана необходимая реализация.
+ */
+public interface PlaywrightLifecycleStrategy {
+
+    /** Выполняется один раз перед всеми тестами в классе. */
+    default void beforeAll(ExtensionContext context) {}
+
+    /** Выполняется перед каждым тестовым методом. */
+    default void beforeEach(ExtensionContext context) {}
+
+    /** Выполняется после каждого тестового метода. */
+    default void afterEach(ExtensionContext context) {}
+
+    /** Выполняется один раз после всех тестов в классе. */
+    default void afterAll(ExtensionContext context) {}
+}
+


### PR DESCRIPTION
## Summary
- introduce PlaywrightLifecycleStrategy with local and BrowserStack implementations
- refactor PlaywrightManager into atomic operations and update JUnit extension

## Testing
- `gradle test -Dapp.headless=true` *(fails: Process 'command ...' finished with non-zero exit value 1 due to ERR_SOCKET_CLOSED during Playwright install)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ad3459f8832f83995be03276d0f2