### PR TITLE
Implement Playwright lifecycle strategies for local and BrowserStack runs

### DIFF
--- a/src/test/java/com/example/testsupport/framework/lifecycle/BrowserStackPlaywrightLifecycle.java
+++ b/src/test/java/com/example/testsupport/framework/lifecycle/BrowserStackPlaywrightLifecycle.java
@@ -1,0 +1,42 @@
+package com.example.testsupport.framework.lifecycle;
+
+import com.example.testsupport.framework.browser.PlaywrightManager;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * Стратегия для BrowserStack: новый браузер и контекст на каждый тест.
+ */
+@Component
+@Profile("browserstack")
+public class BrowserStackPlaywrightLifecycle implements PlaywrightLifecycleStrategy {
+
+    private final PlaywrightManager pm;
+
+    public BrowserStackPlaywrightLifecycle(PlaywrightManager pm) {
+        this.pm = pm;
+    }
+
+    @Override
+    public void beforeAll() {
+        // no-op
+    }
+
+    @Override
+    public void beforeEach() {
+        pm.initializeBrowser();
+        pm.createContextAndPage();
+    }
+
+    @Override
+    public void afterEach() {
+        pm.closeContextAndPage();
+        pm.closeBrowser();
+    }
+
+    @Override
+    public void afterAll() {
+        // no-op
+    }
+}
+

--- a/src/test/java/com/example/testsupport/framework/lifecycle/LocalPlaywrightLifecycle.java
+++ b/src/test/java/com/example/testsupport/framework/lifecycle/LocalPlaywrightLifecycle.java
@@ -1,0 +1,40 @@
+package com.example.testsupport.framework.lifecycle;
+
+import com.example.testsupport.framework.browser.PlaywrightManager;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * Локальная стратегия: один браузер на класс, новый контекст на каждый тест.
+ */
+@Component
+@Profile("local")
+public class LocalPlaywrightLifecycle implements PlaywrightLifecycleStrategy {
+
+    private final PlaywrightManager pm;
+
+    public LocalPlaywrightLifecycle(PlaywrightManager pm) {
+        this.pm = pm;
+    }
+
+    @Override
+    public void beforeAll() {
+        pm.initializeBrowser();
+    }
+
+    @Override
+    public void beforeEach() {
+        pm.createContextAndPage();
+    }
+
+    @Override
+    public void afterEach() {
+        pm.closeContextAndPage();
+    }
+
+    @Override
+    public void afterAll() {
+        pm.closeBrowser();
+    }
+}
+

--- a/src/test/java/com/example/testsupport/framework/lifecycle/PlaywrightLifecycleStrategy.java
+++ b/src/test/java/com/example/testsupport/framework/lifecycle/PlaywrightLifecycleStrategy.java
@@ -1,0 +1,16 @@
+package com.example.testsupport.framework.lifecycle;
+
+/**
+ * Стратегия управления жизненным циклом Playwright для различных профилей запуска.
+ */
+public interface PlaywrightLifecycleStrategy {
+
+    void beforeAll();
+
+    void beforeEach();
+
+    void afterEach();
+
+    void afterAll();
+}
+

--- a/src/test/java/com/example/testsupport/framework/listeners/PlaywrightExtension.java
+++ b/src/test/java/com/example/testsupport/framework/listeners/PlaywrightExtension.java
@@ -1,41 +1,50 @@
 package com.example.testsupport.framework.listeners;
 
+import com.example.testsupport.config.AppProperties;
+import com.example.testsupport.framework.browser.PlaywrightManager;
+import com.example.testsupport.framework.localization.LocalizationService;
+import com.example.testsupport.framework.lifecycle.PlaywrightLifecycleStrategy;
 import com.microsoft.playwright.Page;
 import io.qameta.allure.Allure;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import com.example.testsupport.config.AppProperties;
-import com.example.testsupport.framework.localization.LocalizationService;
-import com.example.testsupport.framework.browser.PlaywrightManager;
 
 /**
  * Расширение JUnit 5, которое управляет жизненным циклом Playwright
  * и создает полезные вложения Allure при падении теста.
  */
-public class PlaywrightExtension implements BeforeEachCallback, AfterEachCallback {
+public class PlaywrightExtension implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback {
 
     private static final Logger log = LoggerFactory.getLogger(PlaywrightExtension.class);
+    private PlaywrightLifecycleStrategy lifecycle;
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        ApplicationContext ctx = SpringExtension.getApplicationContext(context);
+        lifecycle = ctx.getBean(PlaywrightLifecycleStrategy.class);
+        lifecycle.beforeAll();
+    }
 
     @Override
     public void beforeEach(ExtensionContext context) {
         ApplicationContext ctx = SpringExtension.getApplicationContext(context);
+        if (lifecycle == null) {
+            lifecycle = ctx.getBean(PlaywrightLifecycleStrategy.class);
+        }
         LocalizationService ls = ctx.getBean(LocalizationService.class);
         AppProperties props = ctx.getBean(AppProperties.class);
         ls.loadLocale(props.getLanguage());
 
-        PlaywrightManager manager = ctx.getBean(PlaywrightManager.class);
-        manager.getPage();
+        lifecycle.beforeEach();
     }
 
     @Override
     public void afterEach(ExtensionContext context) {
-        PlaywrightManager manager = SpringExtension.getApplicationContext(context)
-                .getBean(PlaywrightManager.class);
+        ApplicationContext ctx = SpringExtension.getApplicationContext(context);
+        PlaywrightManager manager = ctx.getBean(PlaywrightManager.class);
         try {
             if (context.getExecutionException().isPresent()) {
                 Page page = manager.getPage();
@@ -48,7 +57,14 @@ public class PlaywrightExtension implements BeforeEachCallback, AfterEachCallbac
                 }
             }
         } finally {
-            manager.close();
+            lifecycle.afterEach();
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        if (lifecycle != null) {
+            lifecycle.afterAll();
         }
     }
 }

--- a/src/test/java/com/example/testsupport/pages/BasePage.java
+++ b/src/test/java/com/example/testsupport/pages/BasePage.java
@@ -3,17 +3,22 @@ package com.example.testsupport.pages;
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.microsoft.playwright.Page;
 import org.junit.jupiter.api.Assertions;
+import org.springframework.beans.factory.ObjectProvider;
 
 /**
  * Базовый Page Object с общей логикой.
  */
 public abstract class BasePage {
-    protected final Page page;
+    private final ObjectProvider<Page> pageProvider;
     protected final LocalizationService ls;
 
-    protected BasePage(Page page, LocalizationService ls) {
-        this.page = page;
+    protected BasePage(ObjectProvider<Page> pageProvider, LocalizationService ls) {
+        this.pageProvider = pageProvider;
         this.ls = ls;
+    }
+
+    protected Page page() {
+        return pageProvider.getObject();
     }
 
     /**
@@ -22,7 +27,7 @@ public abstract class BasePage {
      * @param expectedPath ожидаемая подстрока URL
      */
     public void verifyUrlContains(String expectedPath) {
-        String current = page.url();
+        String current = page().url();
         Assertions.assertTrue(
                 current.contains(expectedPath),
                 String.format("Ожидалось, что URL содержит '%s', но фактический URL '%s'", expectedPath, current)

--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -3,6 +3,7 @@ package com.example.testsupport.pages;
 import com.example.testsupport.config.AppProperties;
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.microsoft.playwright.Page;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -16,7 +17,7 @@ import org.springframework.stereotype.Component;
 public class CasinoPage extends BasePage {
     private final AppProperties props;
 
-    public CasinoPage(Page page, AppProperties props, LocalizationService ls) {
+    public CasinoPage(ObjectProvider<Page> page, AppProperties props, LocalizationService ls) {
         super(page, ls);
         this.props = props;
     }

--- a/src/test/java/com/example/testsupport/pages/MainPage.java
+++ b/src/test/java/com/example/testsupport/pages/MainPage.java
@@ -1,18 +1,19 @@
 package com.example.testsupport.pages;
 
 import com.microsoft.playwright.Locator;
-import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 import com.example.testsupport.framework.localization.LocalizationService;
+import org.springframework.beans.factory.ObjectProvider;
+import com.microsoft.playwright.Page;
 
 @Component
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class MainPage extends BasePage {
 
-    public MainPage(Page page, LocalizationService ls) {
+    public MainPage(ObjectProvider<Page> page, LocalizationService ls) {
         super(page, ls);
     }
 
@@ -23,7 +24,7 @@ public class MainPage extends BasePage {
      */
     public Locator casinoLink() {
         String casinoText = ls.get("header.menu.casino");
-        return page.getByRole(AriaRole.NAVIGATION)
+        return page().getByRole(AriaRole.NAVIGATION)
                 .getByRole(AriaRole.LINK,
                         new Locator.GetByRoleOptions()
                                 .setName(casinoText)
@@ -34,6 +35,6 @@ public class MainPage extends BasePage {
      * Переходит на страницу казино через меню.
      */
     public void clickCasino() {
-        page.waitForNavigation(() -> casinoLink().click());
+        page().waitForNavigation(() -> casinoLink().click());
     }
 }


### PR DESCRIPTION
## Summary
- introduce `PlaywrightLifecycleStrategy` with `local` and `browserstack` implementations
- refactor `PlaywrightManager` into atomic lifecycle operations
- delegate JUnit extension hooks to the selected lifecycle strategy and load page objects lazily

## Testing
- `gradle test` *(fails: Error [ERR_SOCKET_CLOSED]: Socket is closed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ad3459f8832f83995be03276d0f2