### PR TITLE
feat: add device parameterization for responsive tests

### DIFF
--- a/src/test/java/com/example/testsupport/framework/device/Device.java
+++ b/src/test/java/com/example/testsupport/framework/device/Device.java
@@ -1,0 +1,11 @@
+package com.example.testsupport.framework.device;
+
+/**
+ * Описание устройства для тестирования, включая его имя и размер в пикселях.
+ */
+public record Device(String name, int width, int height) {
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/src/test/java/com/example/testsupport/pages/MainPage.java
+++ b/src/test/java/com/example/testsupport/pages/MainPage.java
@@ -1,13 +1,13 @@
 package com.example.testsupport.pages;
 
 import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 import com.example.testsupport.framework.localization.LocalizationService;
-import org.springframework.beans.factory.ObjectProvider;
-import com.microsoft.playwright.Page;
 
 @Component
 @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
@@ -17,18 +17,30 @@ public class MainPage extends BasePage {
         super(page, ls);
     }
 
+    private static final int MOBILE_BREAKPOINT = 960;
+
     /**
-     * Возвращает локатор ссылки «Казино» в меню.
+     * Возвращает локатор элемента «Казино» в меню, учитывая адаптивную верстку.
      *
-     * @return локатор ссылки
+     * @return локатор ссылки или вкладки «Казино»
      */
     public Locator casinoLink() {
         String casinoText = ls.get("header.menu.casino");
-        return page().getByRole(AriaRole.NAVIGATION)
-                .getByRole(AriaRole.LINK,
-                        new Locator.GetByRoleOptions()
-                                .setName(casinoText)
-                                .setExact(true));
+        int currentWidth = page().viewportSize().width;
+
+        if (currentWidth < MOBILE_BREAKPOINT) {
+            // --- Локатор для мобильной версии ---
+            return page().getByRole(
+                    AriaRole.TAB,
+                    new Page.GetByRoleOptions().setName(casinoText).setExact(true)
+            );
+        } else {
+            // --- Локатор для десктопной версии ---
+            return page().getByRole(AriaRole.NAVIGATION)
+                    .getByRole(AriaRole.LINK, new Locator.GetByRoleOptions()
+                            .setName(casinoText)
+                            .setExact(true));
+        }
     }
 
     /**

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -2,6 +2,7 @@ package tests;
 
 import com.example.testsupport.TestApplication;
 import com.example.testsupport.framework.browser.PlaywrightManager;
+import com.example.testsupport.framework.device.Device;
 import com.example.testsupport.framework.listeners.PlaywrightExtension;
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.example.testsupport.pages.CasinoPage;
@@ -14,6 +15,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.List;
 import java.util.stream.Stream;
 
 import static io.qameta.allure.Allure.step;
@@ -28,15 +32,26 @@ class MultilingualNavigationTest {
     @Autowired private PlaywrightManager playwrightManager;
     @Autowired private LocalizationService ls;
 
-    static Stream<String> languageProvider() {
-        return Stream.of("lv", "ru", "en");
+    static Stream<Arguments> deviceAndLanguageProvider() {
+        List<String> languages = List.of("lv", "ru", "en");
+        List<Device> devices = List.of(
+                new Device("Desktop", 1920, 1080),
+                new Device("Mobile", 390, 844)
+        );
+
+        return devices.stream()
+                .flatMap(device -> languages.stream().map(lang -> Arguments.of(device, lang)));
     }
 
-    @Story("Переход на страницу казино для всех поддерживаемых языков")
-    @DisplayName("Навигация на страницу казино для языка:")
-    @ParameterizedTest(name = "[Язык: {0}]")
-    @MethodSource("languageProvider")
-    void navigateToCasinoPageOnAllLanguages(String languageCode) {
+    @Story("Переход на страницу казино для всех поддерживаемых языков и устройств")
+    @DisplayName("Навигация на страницу казино")
+    @ParameterizedTest(name = "[Устройство: {0}, Язык: {1}]")
+    @MethodSource("deviceAndLanguageProvider")
+    void navigateToCasinoPageOnAllLanguagesAndDevices(Device device, String languageCode) {
+
+        step("Устанавливаем размер окна просмотра", () -> {
+            playwrightManager.getPage().setViewportSize(device.width(), device.height());
+        });
 
         step("Устанавливаем язык теста", () -> {
             ls.loadLocale(languageCode);


### PR DESCRIPTION
## Summary
- add Device abstraction to describe test devices
- parameterize navigation test across languages and devices with viewport setup
- adapt MainPage locator to switch between desktop link and mobile tab

## Testing
- `gradle test --no-daemon` *(fails: Process 'command '/root/.local/share/mise/installs/java/21.0.2/bin/java'' finished with non-zero exit value 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b56cf494832fad64561a7950ace5