### PR TITLE
feat: externalize device configuration

### DIFF
--- a/src/test/java/com/example/testsupport/framework/device/DeviceConfiguration.java
+++ b/src/test/java/com/example/testsupport/framework/device/DeviceConfiguration.java
@@ -1,0 +1,24 @@
+package com.example.testsupport.framework.device;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+/**
+ * Loads device definitions from {@code devices.yml}.
+ */
+@Component
+@ConfigurationProperties(prefix = "test-devices")
+@PropertySource(value = "classpath:devices.yml", factory = YamlPropertySourceFactory.class)
+public class DeviceConfiguration {
+    private List<Device> platforms;
+
+    public List<Device> getPlatforms() {
+        return platforms;
+    }
+
+    public void setPlatforms(List<Device> platforms) {
+        this.platforms = platforms;
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/device/DeviceProvider.java
+++ b/src/test/java/com/example/testsupport/framework/device/DeviceProvider.java
@@ -1,0 +1,58 @@
+package com.example.testsupport.framework.device;
+
+import com.example.testsupport.config.AppProperties;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Provides combinations of devices and languages for parameterized tests.
+ */
+public class DeviceProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        ApplicationContext ctx = SpringExtension.getApplicationContext(context);
+        DeviceConfiguration deviceConfig = ctx.getBean(DeviceConfiguration.class);
+        AppProperties props = ctx.getBean(AppProperties.class);
+
+        List<Device> allDevices = deviceConfig.getPlatforms();
+        List<String> languages = props.getLanguages();
+        if (languages == null || languages.isEmpty()) {
+            languages = List.of("lv", "ru", "en");
+        }
+        final List<String> finalLanguages = languages;
+
+        String filter = System.getProperty("test.devices");
+        List<Device> devices;
+        if (filter == null || filter.isBlank()) {
+            devices = allDevices;
+        } else {
+            Set<String> requested = Arrays.stream(filter.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toSet());
+            Map<String, Device> deviceMap = allDevices.stream()
+                    .collect(Collectors.toMap(Device::name, d -> d));
+            List<String> missing = requested.stream()
+                    .filter(name -> !deviceMap.containsKey(name))
+                    .toList();
+            if (!missing.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Device(s) not found in configuration: " + String.join(", ", missing));
+            }
+            devices = requested.stream().map(deviceMap::get).toList();
+        }
+
+        return devices.stream()
+                .flatMap(device -> finalLanguages.stream()
+                        .map(lang -> Arguments.of(device, lang)));
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/device/YamlPropertySourceFactory.java
+++ b/src/test/java/com/example/testsupport/framework/device/YamlPropertySourceFactory.java
@@ -1,0 +1,24 @@
+package com.example.testsupport.framework.device;
+
+import java.io.IOException;
+import java.util.Properties;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.support.EncodedResource;
+import org.springframework.core.io.support.PropertySourceFactory;
+
+/**
+ * Allows loading YAML files via {@link org.springframework.context.annotation.PropertySource}.
+ */
+public class YamlPropertySourceFactory implements PropertySourceFactory {
+    @Override
+    public PropertySource<?> createPropertySource(String name, EncodedResource resource) throws IOException {
+        YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+        factory.setResources(resource.getResource());
+        Properties properties = factory.getObject();
+        return new PropertiesPropertySource(
+                name != null ? name : resource.getResource().getFilename(),
+                properties != null ? properties : new Properties());
+    }
+}

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -6,18 +6,14 @@ import com.example.testsupport.framework.device.Device;
 import com.example.testsupport.framework.listeners.PlaywrightExtension;
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.example.testsupport.pages.MainPage;
+import com.example.testsupport.framework.device.DeviceProvider;
 import io.qameta.allure.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import org.junit.jupiter.params.provider.Arguments;
-
-import java.util.List;
-import java.util.stream.Stream;
 
 import static com.example.testsupport.framework.utils.AllureHelper.step;
 
@@ -30,21 +26,10 @@ class MultilingualNavigationTest {
     @Autowired private PlaywrightManager playwrightManager;
     @Autowired private LocalizationService ls;
 
-    static Stream<Arguments> deviceAndLanguageProvider() {
-        List<String> languages = List.of("lv", "ru", "en");
-        List<Device> devices = List.of(
-                new Device("Desktop", 1920, 1080),
-                new Device("Mobile", 390, 844)
-        );
-
-        return devices.stream()
-                .flatMap(device -> languages.stream().map(lang -> Arguments.of(device, lang)));
-    }
-
     @Story("Переход на страницу казино для всех поддерживаемых языков и устройств")
     @DisplayName("Навигация на страницу казино")
     @ParameterizedTest(name = "[Устройство: {0}, Язык: {1}]")
-    @MethodSource("deviceAndLanguageProvider")
+    @ArgumentsSource(DeviceProvider.class)
     void navigateToCasinoPageOnAllLanguagesAndDevices(Device device, String languageCode) {
 
         step("Устанавливаем размер окна просмотра", () -> {

--- a/src/test/resources/devices.yml
+++ b/src/test/resources/devices.yml
@@ -1,0 +1,43 @@
+# Список устройств для тестирования адаптивной верстки.
+# Используется для локальной эмуляции и может быть отфильтрован
+# через системное свойство -Dtest.devices="name1,name2"
+
+test-devices:
+  # Этот список будет загружен в приложение
+  platforms:
+    - name: "Desktop FullHD"
+      width: 1920
+      height: 1080
+    - name: "MacBook Pro"
+      width: 1440
+      height: 900
+    - name: "iPhone 16 (Pro Max)"
+      width: 430
+      height: 932
+    - name: "iPhone 15"
+      width: 393
+      height: 852
+    - name: "iPhone 11"
+      width: 414
+      height: 896
+    - name: "Samsung S25 Ultra"
+      width: 384
+      height: 854
+    - name: "Samsung S24"
+      width: 360
+      height: 800
+    - name: "Samsung S20"
+      width: 360
+      height: 800
+    - name: "Huawei P30"
+      width: 360
+      height: 780
+    - name: "iPad Pro 11"
+      width: 834
+      height: 1194
+    - name: "iPad Air 6"
+      width: 820
+      height: 1180
+    - name: "iPad Mini"
+      width: 744
+      height: 1133


### PR DESCRIPTION
## Summary
- load UI test devices from `devices.yml` via Spring configuration
- add `DeviceProvider` to filter devices by `test.devices` system property
- refactor navigation test to use new provider and drop hardcoded device list

## Testing
- `gradle test -x playwrightInstall` *(fails: Failed to install browsers, exit code: 1)*


------
https://chatgpt.com/codex/tasks/task_e_68ab3ff81ff8832fa6a1b34d7f13b754