### PR TITLE
refactor: replace network idle waits with UI readiness checks

### DIFF
--- a/src/main/java/com/example/testsupport/framework/browser/PlaywrightManager.java
+++ b/src/main/java/com/example/testsupport/framework/browser/PlaywrightManager.java
@@ -1,7 +1,6 @@
 package com.example.testsupport.framework.browser;
 
 import com.microsoft.playwright.*;
-import com.microsoft.playwright.options.WaitUntilState;
 import com.example.testsupport.config.AppProperties;
 import com.example.testsupport.framework.localization.LocalizationService;
 import org.springframework.stereotype.Component;
@@ -93,8 +92,7 @@ public class PlaywrightManager {
     }
 
     public void open() {
-        getPage().navigate(buildBaseUrlForCurrentLanguage(),
-                new Page.NavigateOptions().setWaitUntil(WaitUntilState.NETWORKIDLE));
+        getPage().navigate(buildBaseUrlForCurrentLanguage());
     }
 
     /**
@@ -103,8 +101,7 @@ public class PlaywrightManager {
      * @param path e.g., "/casino"
      */
     public void navigate(String path) {
-        getPage().navigate(buildBaseUrlForCurrentLanguage() + path,
-                new Page.NavigateOptions().setWaitUntil(WaitUntilState.NETWORKIDLE));
+        getPage().navigate(buildBaseUrlForCurrentLanguage() + path);
     }
     /**
      * Closes the page and context.

--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -39,7 +39,23 @@ public class CasinoPage extends BasePage {
     /**
      * Verifies that current URL contains expected path.
      */
-    public void verifyUrl() {
-        step("Проверка URL страницы 'Казино'", () -> verifyUrlContains(getExpectedPath()));
+    public CasinoPage verifyUrl() {
+        return step("Проверка URL страницы 'Казино'", () -> {
+            verifyUrlContains(getExpectedPath());
+            return this;
+        });
+    }
+
+    /**
+     * Verifies that the casino page is loaded.
+     *
+     * @return current page object
+     */
+    public CasinoPage verifyIsLoaded() {
+        return step("Проверка загрузки страницы 'Казино'", () -> {
+            header().verifyLogoVisible();
+            verifyUrlContains(getExpectedPath());
+            return this;
+        });
     }
 }

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -45,7 +45,7 @@ class MultilingualNavigationTest {
 
         step("Переходим на страницу 'Казино'", () -> {
             mainPage.navigateToCasino()
-                    .verifyUrl();
+                    .verifyIsLoaded();
         });
 
     }


### PR DESCRIPTION
## Summary
- drop NETWORKIDLE waits from Playwright navigation
- add explicit `verifyIsLoaded` check for Casino page and test

## Testing
- `gradle test --no-daemon` *(fails: Failed to download Chromium 130.0.6723.31)*

------
https://chatgpt.com/codex/tasks/task_e_68ab657f3848832fa2482f0534ec8a5c