### PR TITLE
refactor: centralize test environment setup

### DIFF
--- a/src/test/java/tests/BaseTest.java
+++ b/src/test/java/tests/BaseTest.java
@@ -1,0 +1,31 @@
+package tests;
+
+import com.example.testsupport.TestApplication;
+import com.example.testsupport.framework.browser.PlaywrightManager;
+import com.example.testsupport.framework.device.Device;
+import com.example.testsupport.framework.listeners.PlaywrightExtension;
+import com.example.testsupport.framework.localization.LocalizationService;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static com.example.testsupport.framework.utils.AllureHelper.step;
+
+@SpringBootTest(classes = TestApplication.class)
+@ExtendWith(PlaywrightExtension.class)
+public abstract class BaseTest {
+
+    @Autowired protected PlaywrightManager playwrightManager;
+    @Autowired protected LocalizationService ls;
+
+    protected void setupTestEnvironment(Device device, String languageCode) {
+        step("Устанавливаем размер окна просмотра", () -> {
+            playwrightManager.getPage().setViewportSize(device.width(), device.height());
+        });
+
+        step("Устанавливаем язык теста", () -> {
+            ls.loadLocale(languageCode);
+        });
+    }
+}
+

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -1,44 +1,29 @@
 package tests;
 
-import com.example.testsupport.TestApplication;
-import com.example.testsupport.framework.browser.PlaywrightManager;
 import com.example.testsupport.framework.device.Device;
-import com.example.testsupport.framework.listeners.PlaywrightExtension;
-import com.example.testsupport.framework.localization.LocalizationService;
 import com.example.testsupport.pages.MainPage;
 import com.example.testsupport.framework.device.DeviceProvider;
 import io.qameta.allure.*;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import static com.example.testsupport.framework.utils.AllureHelper.step;
 
 @Epic("Spelet.lv")
 @Feature("Навигация по шапке")
-@SpringBootTest(classes = TestApplication.class)
-@ExtendWith(PlaywrightExtension.class)
-class MultilingualNavigationTest {
+class MultilingualNavigationTest extends BaseTest {
     @Autowired private MainPage mainPage;
-    @Autowired private PlaywrightManager playwrightManager;
-    @Autowired private LocalizationService ls;
 
     @Story("Переход на страницу казино для всех поддерживаемых языков и устройств")
     @DisplayName("Навигация на страницу казино")
     @ParameterizedTest(name = "[Устройство: {0}, Язык: {1}]")
     @ArgumentsSource(DeviceProvider.class)
     void navigateToCasinoPageOnAllLanguagesAndDevices(Device device, String languageCode) {
-
-        step("Устанавливаем размер окна просмотра", () -> {
-            playwrightManager.getPage().setViewportSize(device.width(), device.height());
-        });
-
-        step("Устанавливаем язык теста", () -> {
-            ls.loadLocale(languageCode);
-        });
+        step(String.format("Подготовка тестового окружения [Устройство: %s, Язык: %s]",
+                device, languageCode),
+            () -> setupTestEnvironment(device, languageCode));
 
         step("Открываем главную страницу", () -> {
             mainPage.open()


### PR DESCRIPTION
## Summary
- introduce abstract `BaseTest` with shared dependencies and `setupTestEnvironment`
- simplify `MultilingualNavigationTest` by using base class and encapsulated preparation
- move environment setup step to test for clearer Allure reporting

## Testing
- `gradle test` *(fails: Failed to download Chromium 130.0.6723.31)*

------
https://chatgpt.com/codex/tasks/task_e_68ab77e121b8832fa8f7b0d632c5b862