### PR TITLE
Add casino filters drawer component and multilingual test

### DIFF
--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -2,7 +2,10 @@ package com.example.testsupport.pages;
 
 import com.example.testsupport.config.AppProperties;
 import com.example.testsupport.framework.localization.LocalizationService;
+import com.example.testsupport.pages.components.FiltersDrawerComponent;
+import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.AriaRole;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
@@ -57,6 +60,23 @@ public class CasinoPage extends BasePage<CasinoPage> {
             header().verifyLogoVisible();
             verifyUrlContains(getExpectedPath());
             return this;
+        });
+    }
+
+    /**
+     * Clicks on the filters button and returns the filters drawer component.
+     *
+     * @return filters drawer component
+     */
+    public FiltersDrawerComponent openFilters() {
+        return step("Открываем модуль фильтров", () -> {
+            String buttonText = ls.get("casino.filters.button");
+            page().getByRole(AriaRole.BUTTON, new Locator.GetByRoleOptions()
+                    .setName(buttonText)
+                    .setExact(true))
+                .click();
+            Locator drawerRoot = page().locator("div.drawer");
+            return new FiltersDrawerComponent(drawerRoot, ls);
         });
     }
 }

--- a/src/test/java/com/example/testsupport/pages/components/FiltersDrawerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/FiltersDrawerComponent.java
@@ -1,0 +1,36 @@
+package com.example.testsupport.pages.components;
+
+import com.example.testsupport.framework.localization.LocalizationService;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.options.AriaRole;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static com.example.testsupport.framework.utils.AllureHelper.step;
+
+/**
+ * Component representing the filters drawer.
+ */
+public class FiltersDrawerComponent extends BaseComponent {
+    private final LocalizationService ls;
+
+    public FiltersDrawerComponent(Locator root, LocalizationService ls) {
+        super(root);
+        this.ls = ls;
+    }
+
+    /**
+     * Verifies that the filters drawer is visible by checking its header.
+     *
+     * @return current component instance
+     */
+    public FiltersDrawerComponent verifyIsVisible() {
+        return step("Проверка, что дровер фильтров отображается", () -> {
+            String title = ls.get("casino.filters.drawer.title");
+            assertThat(root.getByRole(AriaRole.HEADING, new Locator.GetByRoleOptions()
+                    .setName(title)
+                    .setExact(true))).isVisible();
+            return this;
+        });
+    }
+}
+

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -3,10 +3,12 @@ package tests;
 import com.example.testsupport.TestApplication;
 import com.example.testsupport.framework.browser.PlaywrightManager;
 import com.example.testsupport.framework.device.Device;
+import com.example.testsupport.framework.device.DeviceProvider;
 import com.example.testsupport.framework.listeners.PlaywrightExtension;
 import com.example.testsupport.framework.localization.LocalizationService;
+import com.example.testsupport.pages.CasinoPage;
 import com.example.testsupport.pages.MainPage;
-import com.example.testsupport.framework.device.DeviceProvider;
+import com.example.testsupport.pages.components.FiltersDrawerComponent;
 import io.qameta.allure.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,11 +28,17 @@ class MultilingualNavigationTest {
     @Autowired private PlaywrightManager playwrightManager;
     @Autowired private LocalizationService ls;
 
-    @Story("Переход на страницу казино для всех поддерживаемых языков и устройств")
-    @DisplayName("Навигация на страницу казино")
+    @Story("Переход на страницу казино и открытие фильтров для всех поддерживаемых языков и устройств")
+    @DisplayName("Навигация на страницу казино и фильтры")
     @ParameterizedTest(name = "[Устройство: {0}, Язык: {1}]")
     @ArgumentsSource(DeviceProvider.class)
     void navigateToCasinoPageOnAllLanguagesAndDevices(Device device, String languageCode) {
+
+        final class TestData {
+            CasinoPage casinoPage;
+            FiltersDrawerComponent filtersDrawer;
+        }
+        final TestData ctx = new TestData();
 
         step("Устанавливаем размер окна просмотра", () -> {
             playwrightManager.getPage().setViewportSize(device.width(), device.height());
@@ -46,8 +54,16 @@ class MultilingualNavigationTest {
         });
 
         step("Переходим на страницу 'Казино'", () -> {
-            mainPage.navigateToCasino()
+            ctx.casinoPage = mainPage.navigateToCasino()
                     .verifyIsLoaded();
+        });
+
+        step("Нажимаем кнопку 'Фильтры'", () -> {
+            ctx.filtersDrawer = ctx.casinoPage.openFilters();
+        });
+
+        step("Проверяем, что модуль фильтров отображается", () -> {
+            ctx.filtersDrawer.verifyIsVisible();
         });
     }
 }

--- a/src/test/resources/locales/en.properties
+++ b/src/test/resources/locales/en.properties
@@ -1,1 +1,3 @@
 header.menu.casino = Casino
+casino.filters.button = Filters
+casino.filters.drawer.title = Filter

--- a/src/test/resources/locales/lv.properties
+++ b/src/test/resources/locales/lv.properties
@@ -1,1 +1,3 @@
 header.menu.casino = Kazino
+casino.filters.button = Filtri
+casino.filters.drawer.title = Filtrs

--- a/src/test/resources/locales/ru.properties
+++ b/src/test/resources/locales/ru.properties
@@ -1,1 +1,3 @@
 header.menu.casino = Казино
+casino.filters.button = Фильтры
+casino.filters.drawer.title = Фильтр


### PR DESCRIPTION
## Summary
- add component for the casino filters drawer
- navigate to casino page and open filters across languages and devices
- localize filter button and drawer header translations

## Testing
- `gradle test` *(fails: Gradle daemon started but build did not complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68af70cda0b8832fab21952da3f5331f