### PR TITLE
test: add filter drawer multilingual coverage

### DIFF
--- a/src/test/java/com/example/testsupport/framework/utils/Breakpoints.java
+++ b/src/test/java/com/example/testsupport/framework/utils/Breakpoints.java
@@ -1,0 +1,18 @@
+package com.example.testsupport.framework.utils;
+
+/**
+ * Common viewport breakpoints used in tests for responsive behavior.
+ */
+public final class Breakpoints {
+    private Breakpoints() {}
+
+    /**
+     * Width below which layout switches to mobile navigation.
+     */
+    public static final int MOBILE = 960;
+
+    /**
+     * Width below which certain buttons collapse to icon-only variants.
+     */
+    public static final int TABLET = 768;
+}

--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -2,7 +2,9 @@ package com.example.testsupport.pages;
 
 import com.example.testsupport.config.AppProperties;
 import com.example.testsupport.framework.localization.LocalizationService;
+import com.example.testsupport.framework.utils.Breakpoints;
 import com.example.testsupport.pages.components.FilterDrawerComponent;
+import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
 import org.springframework.beans.factory.ObjectProvider;
@@ -69,11 +71,17 @@ public class CasinoPage extends BasePage<CasinoPage> {
      */
     public FilterDrawerComponent openFilters() {
         return step("Открытие панели фильтров", () -> {
-            String buttonText = ls.get("casino.filters.button");
-            page().getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions()
-                    .setName(buttonText)
-                    .setExact(true))
-                    .click();
+            Locator button;
+            int width = page().viewportSize() != null ? page().viewportSize().width : Integer.MAX_VALUE;
+            if (width < Breakpoints.TABLET) {
+                button = page().locator("div.d_block.pos_relative.w768\\:d_none > button");
+            } else {
+                String buttonText = ls.get("casino.filters.button");
+                button = page().getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions()
+                        .setName(buttonText)
+                        .setExact(true));
+            }
+            button.click();
             return new FilterDrawerComponent(page().locator("div.drawer__headerWrapper"), ls);
         });
     }

--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -82,7 +82,8 @@ public class CasinoPage extends BasePage<CasinoPage> {
                         .setExact(true));
             }
             button.click();
-            return new FilterDrawerComponent(page().locator("div.drawer__headerWrapper"), ls);
+            Locator drawer = page().locator("div.drawer__headerWrapper").locator("..");
+            return new FilterDrawerComponent(drawer, ls);
         });
     }
 }

--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -3,7 +3,6 @@ package com.example.testsupport.pages;
 import com.example.testsupport.config.AppProperties;
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.example.testsupport.pages.components.FilterDrawerComponent;
-import static com.example.testsupport.framework.utils.Breakpoints.TABLET;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
 import org.springframework.beans.factory.ObjectProvider;
@@ -70,16 +69,11 @@ public class CasinoPage extends BasePage<CasinoPage> {
      */
     public FilterDrawerComponent openFilters() {
         return step("Открытие панели фильтров", () -> {
-            int width = page().viewportSize().width;
-            if (width < TABLET) {
-                page().locator("button.button--onlyIcon_true").click();
-            } else {
-                String buttonText = ls.get("casino.filters.button");
-                page().getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions()
-                        .setName(buttonText)
-                        .setExact(true))
-                        .click();
-            }
+            String buttonText = ls.get("casino.filters.button");
+            page().getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions()
+                    .setName(buttonText)
+                    .setExact(true))
+                    .click();
             return new FilterDrawerComponent(page().locator("div.drawer__headerWrapper"), ls);
         });
     }

--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -80,8 +80,7 @@ public class CasinoPage extends BasePage<CasinoPage> {
                         .setExact(true))
                         .click();
             }
-            return new FilterDrawerComponent(page().locator("div.drawer__headerWrapper"), ls)
-                    .verifyIsVisible();
+            return new FilterDrawerComponent(page().locator("div.drawer__headerWrapper"), ls);
         });
     }
 }

--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -83,7 +83,7 @@ public class CasinoPage extends BasePage<CasinoPage> {
             }
             button.click();
             Locator drawer = page().locator("div.drawer__headerWrapper").locator("..");
-            return new FilterDrawerComponent(drawer, ls);
+            return new FilterDrawerComponent(drawer, ls, this);
         });
     }
 }

--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -3,6 +3,7 @@ package com.example.testsupport.pages;
 import com.example.testsupport.config.AppProperties;
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.example.testsupport.pages.components.FilterDrawerComponent;
+import static com.example.testsupport.framework.utils.Breakpoints.TABLET;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
 import org.springframework.beans.factory.ObjectProvider;
@@ -69,11 +70,16 @@ public class CasinoPage extends BasePage<CasinoPage> {
      */
     public FilterDrawerComponent openFilters() {
         return step("Открытие панели фильтров", () -> {
-            String buttonText = ls.get("casino.filters.button");
-            page().getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions()
-                    .setName(buttonText)
-                    .setExact(true))
-                    .click();
+            int width = page().viewportSize().width;
+            if (width < TABLET) {
+                page().locator("button.button--onlyIcon_true").click();
+            } else {
+                String buttonText = ls.get("casino.filters.button");
+                page().getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions()
+                        .setName(buttonText)
+                        .setExact(true))
+                        .click();
+            }
             return new FilterDrawerComponent(page().locator("div.drawer__headerWrapper"), ls)
                     .verifyIsVisible();
         });

--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -2,7 +2,9 @@ package com.example.testsupport.pages;
 
 import com.example.testsupport.config.AppProperties;
 import com.example.testsupport.framework.localization.LocalizationService;
+import com.example.testsupport.pages.components.FilterDrawerComponent;
 import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.AriaRole;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
@@ -57,6 +59,23 @@ public class CasinoPage extends BasePage<CasinoPage> {
             header().verifyLogoVisible();
             verifyUrlContains(getExpectedPath());
             return this;
+        });
+    }
+
+    /**
+     * Opens the filter drawer by clicking the corresponding button.
+     *
+     * @return filter drawer component
+     */
+    public FilterDrawerComponent openFilters() {
+        return step("Открытие панели фильтров", () -> {
+            String buttonText = ls.get("casino.filters.button");
+            page().getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions()
+                    .setName(buttonText)
+                    .setExact(true))
+                    .click();
+            return new FilterDrawerComponent(page().locator("div.drawer__headerWrapper"), ls)
+                    .verifyIsVisible();
         });
     }
 }

--- a/src/test/java/com/example/testsupport/pages/MainPage.java
+++ b/src/test/java/com/example/testsupport/pages/MainPage.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 import static com.example.testsupport.framework.utils.AllureHelper.step;
+import static com.example.testsupport.framework.utils.Breakpoints.MOBILE;
 
 
 @Component
@@ -25,8 +26,6 @@ public class MainPage extends BasePage<MainPage> {
         this.playwrightManager = playwrightManager;
     }
 
-    private static final int MOBILE_BREAKPOINT = 960;
-
     /**
      * Navigates to the casino page through the menu, adapting to screen size.
      */
@@ -34,7 +33,7 @@ public class MainPage extends BasePage<MainPage> {
     public CasinoPage navigateToCasino() {
         return step("Навигация на страницу 'Казино'", () -> {
             int currentWidth = page().viewportSize().width;
-            if (currentWidth < MOBILE_BREAKPOINT) {
+            if (currentWidth < MOBILE) {
                 tabBar().clickCasino();
             } else {
                 header().clickCasino();

--- a/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
@@ -33,5 +33,34 @@ public class FilterDrawerComponent extends BaseComponent {
             return this;
         });
     }
+
+    /**
+     * Selects a provider within the drawer by its visible name.
+     *
+     * @param providerName provider label as displayed in UI
+     * @return current component instance
+     */
+    public FilterDrawerComponent selectProvider(String providerName) {
+        return step(String.format("Выбор провайдера '%s'", providerName), () -> {
+            root.getByRole(AriaRole.ROW, new Locator.GetByRoleOptions()
+                    .setName(providerName)
+                    .setExact(true))
+                .click();
+            return this;
+        });
+    }
+
+    /**
+     * Applies the selected filters by clicking the translated "Show" button.
+     */
+    public void clickShow() {
+        step("Применение фильтров", () -> {
+            String showText = ls.get("casino.filters.show");
+            root.getByRole(AriaRole.BUTTON, new Locator.GetByRoleOptions()
+                    .setName(showText)
+                    .setExact(true))
+                .click();
+        });
+    }
 }
 

--- a/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
@@ -1,0 +1,37 @@
+package com.example.testsupport.pages.components;
+
+import com.example.testsupport.framework.localization.LocalizationService;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.options.AriaRole;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static com.example.testsupport.framework.utils.AllureHelper.step;
+
+/**
+ * Component representing the filter drawer on the casino page.
+ */
+public class FilterDrawerComponent extends BaseComponent {
+
+    private final LocalizationService ls;
+
+    public FilterDrawerComponent(Locator root, LocalizationService ls) {
+        super(root);
+        this.ls = ls;
+    }
+
+    /**
+     * Verifies that the filter drawer is visible by checking its title.
+     *
+     * @return current component instance
+     */
+    public FilterDrawerComponent verifyIsVisible() {
+        return step("Проверка видимости дровера фильтров", () -> {
+            String title = ls.get("casino.filters.title");
+            assertThat(root.getByRole(AriaRole.HEADING, new Locator.GetByRoleOptions()
+                    .setName(title)
+                    .setExact(true))).isVisible();
+            return this;
+        });
+    }
+}
+

--- a/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
@@ -20,12 +20,12 @@ public class FilterDrawerComponent extends BaseComponent {
     }
 
     /**
-     * Verifies that the filter drawer is visible by checking its title.
+     * Verifies that the filter drawer is loaded by checking its translated title.
      *
      * @return current component instance
      */
-    public FilterDrawerComponent verifyIsVisible() {
-        return step("Проверка видимости дровера фильтров", () -> {
+    public FilterDrawerComponent verifyIsLoaded() {
+        return step("Проверка загрузки дровера фильтров", () -> {
             String title = ls.get("casino.filters.title");
             assertThat(root.getByRole(AriaRole.HEADING, new Locator.GetByRoleOptions()
                     .setName(title)

--- a/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
@@ -1,6 +1,7 @@
 package com.example.testsupport.pages.components;
 
 import com.example.testsupport.framework.localization.LocalizationService;
+import com.example.testsupport.pages.CasinoPage;
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.options.AriaRole;
 
@@ -13,10 +14,12 @@ import static com.example.testsupport.framework.utils.AllureHelper.step;
 public class FilterDrawerComponent extends BaseComponent {
 
     private final LocalizationService ls;
+    private final CasinoPage casinoPage;
 
-    public FilterDrawerComponent(Locator root, LocalizationService ls) {
+    public FilterDrawerComponent(Locator root, LocalizationService ls, CasinoPage casinoPage) {
         super(root);
         this.ls = ls;
+        this.casinoPage = casinoPage;
     }
 
     /**
@@ -53,13 +56,14 @@ public class FilterDrawerComponent extends BaseComponent {
     /**
      * Applies the selected filters by clicking the translated "Show" button.
      */
-    public void clickShow() {
-        step("Применение фильтров", () -> {
+    public CasinoPage clickShow() {
+        return step("Применение фильтров", () -> {
             String showText = ls.get("casino.filters.show");
             root.getByRole(AriaRole.BUTTON, new Locator.GetByRoleOptions()
                     .setName(showText)
                     .setExact(true))
                 .click();
+            return casinoPage;
         });
     }
 }

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -48,5 +48,14 @@ class MultilingualNavigationTest extends BaseTest {
             ctx.filterDrawer = ctx.casinoPage.openFilters()
                     .verifyIsLoaded();
         });
+
+        step("Выбираем провайдера 'Play'n Go'", () -> {
+            ctx.filterDrawer.selectProvider("Play'n Go");
+        });
+
+        step("Применяем фильтры", () -> {
+            ctx.filterDrawer.clickShow();
+            ctx.casinoPage.verifyIsLoaded();
+        });
     }
 }

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -45,8 +45,7 @@ class MultilingualNavigationTest extends BaseTest {
         });
 
         step("Открываем дровер фильтров", () -> {
-            ctx.filterDrawer = ctx.casinoPage.openFilters()
-                    .verifyIsVisible();
+            ctx.filterDrawer = ctx.casinoPage.openFilters();
         });
     }
 }

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -1,8 +1,10 @@
 package tests;
 
 import com.example.testsupport.framework.device.Device;
-import com.example.testsupport.pages.MainPage;
 import com.example.testsupport.framework.device.DeviceProvider;
+import com.example.testsupport.pages.MainPage;
+import com.example.testsupport.pages.CasinoPage;
+import com.example.testsupport.pages.components.FilterDrawerComponent;
 import io.qameta.allure.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,6 +24,12 @@ class MultilingualNavigationTest extends BaseTest {
     @ArgumentsSource(DeviceProvider.class)
     void navigateToCasinoPageOnAllLanguagesAndDevices(Device device, String languageCode) {
 
+        final class TestContext {
+            CasinoPage casinoPage;
+            FilterDrawerComponent filterDrawer;
+        }
+        final TestContext ctx = new TestContext();
+
         step(String.format("Подготовка тестового окружения [Устройство: %s, Язык: %s]", device, languageCode), () -> {
             setupTestEnvironment(device, languageCode);
         });
@@ -32,8 +40,13 @@ class MultilingualNavigationTest extends BaseTest {
         });
 
         step("Переходим на страницу 'Казино'", () -> {
-            mainPage.navigateToCasino()
+            ctx.casinoPage = mainPage.navigateToCasino()
                     .verifyIsLoaded();
+        });
+
+        step("Открываем дровер фильтров", () -> {
+            ctx.filterDrawer = ctx.casinoPage.openFilters()
+                    .verifyIsVisible();
         });
     }
 }

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -54,8 +54,8 @@ class MultilingualNavigationTest extends BaseTest {
         });
 
         step("Применяем фильтры", () -> {
-            ctx.filterDrawer.clickShow();
-            ctx.casinoPage.verifyIsLoaded();
+            ctx.casinoPage = ctx.filterDrawer.clickShow()
+                    .verifyIsLoaded();
         });
     }
 }

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -45,7 +45,8 @@ class MultilingualNavigationTest extends BaseTest {
         });
 
         step("Открываем дровер фильтров", () -> {
-            ctx.filterDrawer = ctx.casinoPage.openFilters();
+            ctx.filterDrawer = ctx.casinoPage.openFilters()
+                    .verifyIsLoaded();
         });
     }
 }

--- a/src/test/resources/locales/en.properties
+++ b/src/test/resources/locales/en.properties
@@ -1,1 +1,3 @@
 header.menu.casino = Casino
+casino.filters.button = Filters
+casino.filters.title = Filter

--- a/src/test/resources/locales/en.properties
+++ b/src/test/resources/locales/en.properties
@@ -1,3 +1,4 @@
 header.menu.casino = Casino
 casino.filters.button = Filters
 casino.filters.title = Filter
+casino.filters.show = Show

--- a/src/test/resources/locales/lv.properties
+++ b/src/test/resources/locales/lv.properties
@@ -1,3 +1,4 @@
 header.menu.casino = Kazino
 casino.filters.button = Filtri
 casino.filters.title = Filtrs
+casino.filters.show = Parādīt

--- a/src/test/resources/locales/lv.properties
+++ b/src/test/resources/locales/lv.properties
@@ -1,1 +1,3 @@
 header.menu.casino = Kazino
+casino.filters.button = Filtri
+casino.filters.title = Filtrs

--- a/src/test/resources/locales/ru.properties
+++ b/src/test/resources/locales/ru.properties
@@ -1,1 +1,3 @@
 header.menu.casino = Казино
+casino.filters.button = Фильтры
+casino.filters.title = Фильтр

--- a/src/test/resources/locales/ru.properties
+++ b/src/test/resources/locales/ru.properties
@@ -1,3 +1,4 @@
 header.menu.casino = Казино
 casino.filters.button = Фильтры
 casino.filters.title = Фильтр
+casino.filters.show = Показать


### PR DESCRIPTION
## Summary
- verify filter drawer across languages via new FilterDrawer component
- test casino filters button in navigation test
- simplify filter drawer step in navigation test

## Testing
- `gradle test --tests tests.MultilingualNavigationTest` *(fails: Failed to download Chromium 130.0.6723.31 (playwright build v1140))*

------
https://chatgpt.com/codex/tasks/task_e_68af73252328832f8a8b5918896b8635