### PR TITLE
test: add filter drawer multilingual coverage

### DIFF
--- a/src/test/java/com/example/testsupport/framework/utils/Breakpoints.java
+++ b/src/test/java/com/example/testsupport/framework/utils/Breakpoints.java
@@ -1,0 +1,18 @@
+package com.example.testsupport.framework.utils;
+
+/**
+ * Common viewport breakpoints used in tests for responsive behavior.
+ */
+public final class Breakpoints {
+    private Breakpoints() {}
+
+    /**
+     * Width below which layout switches to mobile navigation.
+     */
+    public static final int MOBILE = 960;
+
+    /**
+     * Width below which certain buttons collapse to icon-only variants.
+     */
+    public static final int TABLET = 768;
+}

--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -4,6 +4,7 @@ import com.example.testsupport.config.AppProperties;
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.example.testsupport.framework.utils.Breakpoints;
 import com.example.testsupport.pages.components.FilterDrawerComponent;
+import com.example.testsupport.pages.components.AuthModalComponent;
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
@@ -117,6 +118,22 @@ public class CasinoPage extends BasePage<CasinoPage> {
                     .setHasText(gameName));
             assertThat(card.first()).isVisible();
             return this;
+        });
+    }
+
+    /**
+     * Clicks the play button for the specified game and returns the auth prompt modal.
+     *
+     * @param gameName name of the game whose play button should be clicked
+     * @return authorization modal component
+     */
+    public AuthModalComponent clickPlay(String gameName) {
+        return step(String.format("Запускаем игру '%s'", gameName), () -> {
+            Locator card = page().locator(".GameCard__root").filter(new Locator.FilterOptions()
+                    .setHasText(gameName)).first();
+            card.getByRole(AriaRole.BUTTON).click();
+            Locator dialog = page().locator("div[role='dialog']");
+            return new AuthModalComponent(dialog, ls);
         });
     }
 }

--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -132,7 +132,9 @@ public class CasinoPage extends BasePage<CasinoPage> {
             Locator card = page().locator(".GameCard__root").filter(new Locator.FilterOptions()
                     .setHasText(gameName)).first();
             card.getByRole(AriaRole.BUTTON).click();
-            Locator dialog = page().locator("div[role='dialog']");
+            String promptTitle = ls.get("casino.play.prompt");
+            Locator dialog = page().getByText(promptTitle, new Page.GetByTextOptions()
+                    .setExact(true)).locator("..");
             return new AuthModalComponent(dialog, ls);
         });
     }

--- a/src/test/java/com/example/testsupport/pages/MainPage.java
+++ b/src/test/java/com/example/testsupport/pages/MainPage.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 import static com.example.testsupport.framework.utils.AllureHelper.step;
+import static com.example.testsupport.framework.utils.Breakpoints.MOBILE;
 
 
 @Component
@@ -25,8 +26,6 @@ public class MainPage extends BasePage<MainPage> {
         this.playwrightManager = playwrightManager;
     }
 
-    private static final int MOBILE_BREAKPOINT = 960;
-
     /**
      * Navigates to the casino page through the menu, adapting to screen size.
      */
@@ -34,7 +33,7 @@ public class MainPage extends BasePage<MainPage> {
     public CasinoPage navigateToCasino() {
         return step("Навигация на страницу 'Казино'", () -> {
             int currentWidth = page().viewportSize().width;
-            if (currentWidth < MOBILE_BREAKPOINT) {
+            if (currentWidth < MOBILE) {
                 tabBar().clickCasino();
             } else {
                 header().clickCasino();

--- a/src/test/java/com/example/testsupport/pages/components/AuthModalComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/AuthModalComponent.java
@@ -2,7 +2,6 @@ package com.example.testsupport.pages.components;
 
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.microsoft.playwright.Locator;
-import com.microsoft.playwright.options.AriaRole;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static com.example.testsupport.framework.utils.AllureHelper.step;
@@ -28,8 +27,7 @@ public class AuthModalComponent extends BaseComponent {
     public AuthModalComponent verifyIsLoaded() {
         return step("Проверяем отображение модального окна авторизации", () -> {
             String title = ls.get("casino.play.prompt");
-            assertThat(root.getByRole(AriaRole.HEADING, new Locator.GetByRoleOptions()
-                    .setName(title)
+            assertThat(root.getByText(title, new Locator.GetByTextOptions()
                     .setExact(true))).isVisible();
             return this;
         });

--- a/src/test/java/com/example/testsupport/pages/components/AuthModalComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/AuthModalComponent.java
@@ -1,0 +1,37 @@
+package com.example.testsupport.pages.components;
+
+import com.example.testsupport.framework.localization.LocalizationService;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.options.AriaRole;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static com.example.testsupport.framework.utils.AllureHelper.step;
+
+/**
+ * Component representing the authorization prompt modal that appears when
+ * attempting to launch a game without being logged in.
+ */
+public class AuthModalComponent extends BaseComponent {
+
+    private final LocalizationService ls;
+
+    public AuthModalComponent(Locator root, LocalizationService ls) {
+        super(root);
+        this.ls = ls;
+    }
+
+    /**
+     * Verifies that the modal is visible by asserting its translated title.
+     *
+     * @return current component instance
+     */
+    public AuthModalComponent verifyIsLoaded() {
+        return step("Проверяем отображение модального окна авторизации", () -> {
+            String title = ls.get("casino.play.prompt");
+            assertThat(root.getByRole(AriaRole.HEADING, new Locator.GetByRoleOptions()
+                    .setName(title)
+                    .setExact(true))).isVisible();
+            return this;
+        });
+    }
+}

--- a/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
@@ -1,0 +1,70 @@
+package com.example.testsupport.pages.components;
+
+import com.example.testsupport.framework.localization.LocalizationService;
+import com.example.testsupport.pages.CasinoPage;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.options.AriaRole;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static com.example.testsupport.framework.utils.AllureHelper.step;
+
+/**
+ * Component representing the filter drawer on the casino page.
+ */
+public class FilterDrawerComponent extends BaseComponent {
+
+    private final LocalizationService ls;
+    private final CasinoPage casinoPage;
+
+    public FilterDrawerComponent(Locator root, LocalizationService ls, CasinoPage casinoPage) {
+        super(root);
+        this.ls = ls;
+        this.casinoPage = casinoPage;
+    }
+
+    /**
+     * Verifies that the filter drawer is loaded by checking its translated title.
+     *
+     * @return current component instance
+     */
+    public FilterDrawerComponent verifyIsLoaded() {
+        return step("Проверка загрузки дровера фильтров", () -> {
+            String title = ls.get("casino.filters.title");
+            assertThat(root.getByRole(AriaRole.HEADING, new Locator.GetByRoleOptions()
+                    .setName(title)
+                    .setExact(true))).isVisible();
+            return this;
+        });
+    }
+
+    /**
+     * Selects a provider within the drawer by its visible name.
+     *
+     * @param providerName provider label as displayed in UI
+     * @return current component instance
+     */
+    public FilterDrawerComponent selectProvider(String providerName) {
+        return step(String.format("Выбор провайдера '%s'", providerName), () -> {
+            root.getByRole(AriaRole.ROW, new Locator.GetByRoleOptions()
+                    .setName(providerName)
+                    .setExact(true))
+                .click();
+            return this;
+        });
+    }
+
+    /**
+     * Applies the selected filters by clicking the translated "Show" button.
+     */
+    public CasinoPage clickShow() {
+        return step("Применение фильтров", () -> {
+            String showText = ls.get("casino.filters.show");
+            root.getByRole(AriaRole.BUTTON, new Locator.GetByRoleOptions()
+                    .setName(showText)
+                    .setExact(true))
+                .click();
+            return casinoPage;
+        });
+    }
+}
+

--- a/src/test/java/com/example/testsupport/pages/components/TabBarComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/TabBarComponent.java
@@ -28,15 +28,4 @@ public class TabBarComponent extends BaseComponent {
                     .click();
         });
     }
-
-    /**
-     * Opens the user profile.
-     */
-    public void openProfile() {
-        step("Открытие профиля пользователя", () ->
-            root.getByRole(AriaRole.TAB, new Locator.GetByRoleOptions()
-                    .setName("Profile"))
-                    .click()
-        );
-    }
 }

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -5,6 +5,7 @@ import com.example.testsupport.framework.device.DeviceProvider;
 import com.example.testsupport.pages.MainPage;
 import com.example.testsupport.pages.CasinoPage;
 import com.example.testsupport.pages.components.FilterDrawerComponent;
+import com.example.testsupport.pages.components.AuthModalComponent;
 import io.qameta.allure.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,6 +28,7 @@ class MultilingualNavigationTest extends BaseTest {
         final class TestContext {
             CasinoPage casinoPage;
             FilterDrawerComponent filterDrawer;
+            AuthModalComponent authModal;
         }
         final TestContext ctx = new TestContext();
 
@@ -61,6 +63,11 @@ class MultilingualNavigationTest extends BaseTest {
         step("Ищем игру 'Book of Dead'", () -> {
             ctx.casinoPage.typeInSearch("Book of Dead")
                     .waitForGameVisible("Book of Dead");
+        });
+
+        step("Запускаем игру 'Book of Dead'", () -> {
+            ctx.authModal = ctx.casinoPage.clickPlay("Book of Dead")
+                    .verifyIsLoaded();
         });
     }
 }

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -1,8 +1,10 @@
 package tests;
 
 import com.example.testsupport.framework.device.Device;
-import com.example.testsupport.pages.MainPage;
 import com.example.testsupport.framework.device.DeviceProvider;
+import com.example.testsupport.pages.MainPage;
+import com.example.testsupport.pages.CasinoPage;
+import com.example.testsupport.pages.components.FilterDrawerComponent;
 import io.qameta.allure.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,6 +24,12 @@ class MultilingualNavigationTest extends BaseTest {
     @ArgumentsSource(DeviceProvider.class)
     void navigateToCasinoPageOnAllLanguagesAndDevices(Device device, String languageCode) {
 
+        final class TestContext {
+            CasinoPage casinoPage;
+            FilterDrawerComponent filterDrawer;
+        }
+        final TestContext ctx = new TestContext();
+
         step(String.format("Подготовка тестового окружения [Устройство: %s, Язык: %s]", device, languageCode), () -> {
             setupTestEnvironment(device, languageCode);
         });
@@ -32,8 +40,27 @@ class MultilingualNavigationTest extends BaseTest {
         });
 
         step("Переходим на страницу 'Казино'", () -> {
-            mainPage.navigateToCasino()
+            ctx.casinoPage = mainPage.navigateToCasino()
                     .verifyIsLoaded();
+        });
+
+        step("Открываем дровер фильтров", () -> {
+            ctx.filterDrawer = ctx.casinoPage.openFilters()
+                    .verifyIsLoaded();
+        });
+
+        step("Выбираем провайдера 'Play'n Go'", () -> {
+            ctx.filterDrawer.selectProvider("Play'n Go");
+        });
+
+        step("Применяем фильтры", () -> {
+            ctx.casinoPage = ctx.filterDrawer.clickShow()
+                    .verifyIsLoaded();
+        });
+
+        step("Ищем игру 'Book of Dead'", () -> {
+            ctx.casinoPage.typeInSearch("Book of Dead")
+                    .waitForGameVisible("Book of Dead");
         });
     }
 }

--- a/src/test/resources/locales/en.properties
+++ b/src/test/resources/locales/en.properties
@@ -3,3 +3,4 @@ casino.filters.button = Filters
 casino.filters.title = Filter
 casino.filters.show = Show
 casino.search.input = Search
+casino.play.prompt = Want to play?

--- a/src/test/resources/locales/en.properties
+++ b/src/test/resources/locales/en.properties
@@ -1,1 +1,5 @@
 header.menu.casino = Casino
+casino.filters.button = Filters
+casino.filters.title = Filter
+casino.filters.show = Show
+casino.search.input = Search

--- a/src/test/resources/locales/lv.properties
+++ b/src/test/resources/locales/lv.properties
@@ -1,1 +1,5 @@
 header.menu.casino = Kazino
+casino.filters.button = Filtri
+casino.filters.title = Filtrs
+casino.filters.show = Parādīt
+casino.search.input = Meklēšana

--- a/src/test/resources/locales/lv.properties
+++ b/src/test/resources/locales/lv.properties
@@ -3,3 +3,4 @@ casino.filters.button = Filtri
 casino.filters.title = Filtrs
 casino.filters.show = Parādīt
 casino.search.input = Meklēšana
+casino.play.prompt = Vēlaties uzspēlēt?

--- a/src/test/resources/locales/ru.properties
+++ b/src/test/resources/locales/ru.properties
@@ -1,1 +1,5 @@
 header.menu.casino = Казино
+casino.filters.button = Фильтры
+casino.filters.title = Фильтр
+casino.filters.show = Показать
+casino.search.input = Поиск

--- a/src/test/resources/locales/ru.properties
+++ b/src/test/resources/locales/ru.properties
@@ -3,3 +3,4 @@ casino.filters.button = Фильтры
 casino.filters.title = Фильтр
 casino.filters.show = Показать
 casino.search.input = Поиск
+casino.play.prompt = Хотите поиграть?


### PR DESCRIPTION
## Summary
- centralize responsive breakpoints for tests
- adapt casino filter button to icon variant on small screens
- reuse breakpoint in navigation
- model filter drawer as component and keep page-object actions atomic
- click filter button by translated name to avoid strict mode locator conflicts
- handle narrow screens by targeting the hidden icon-only filter button
- support selecting providers and applying filters via localized "Show" button
- return to casino page after applying filters for chainable verification
- enable localized casino search and await game visibility

## Testing
- `gradle compileTestJava`
- `gradle test --tests tests.MultilingualNavigationTest` *(fails: Failed to download Chromium 130.0.6723.31 (playwright build v1140))*

------
https://chatgpt.com/codex/tasks/task_e_68af73252328832f8a8b5918896b8635