### PR TITLE
refactor: streamline test setup and dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ repositories { mavenCentral() }
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
         implementation 'com.microsoft.playwright:playwright:1.48.0'
-        implementation 'org.json:json:20240303'
         implementation 'com.fasterxml.jackson.core:jackson-databind'
         implementation 'com.fasterxml.jackson.core:jackson-core'
 

--- a/src/test/java/com/example/testsupport/pages/BasePage.java
+++ b/src/test/java/com/example/testsupport/pages/BasePage.java
@@ -6,7 +6,6 @@ import com.example.testsupport.pages.components.TabBarComponent;
 import com.microsoft.playwright.Page;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.beans.factory.ObjectProvider;
-import java.util.function.Supplier;
 
 /**
  * Base Page Object with shared logic.
@@ -14,15 +13,19 @@ import java.util.function.Supplier;
 public abstract class BasePage<T extends BasePage<T>> {
     private final ObjectProvider<Page> pageProvider;
     protected final LocalizationService ls;
-    private final Supplier<HeaderComponent> header;
-    private final Supplier<TabBarComponent> tabBar;
+    private final ObjectProvider<HeaderComponent> headerProvider;
+    private final ObjectProvider<TabBarComponent> tabBarProvider;
+    private HeaderComponent header;
+    private TabBarComponent tabBar;
 
     @SuppressWarnings("resource")
-    protected BasePage(ObjectProvider<Page> pageProvider, LocalizationService ls) {
+    protected BasePage(ObjectProvider<Page> pageProvider, LocalizationService ls,
+                       ObjectProvider<HeaderComponent> headerProvider,
+                       ObjectProvider<TabBarComponent> tabBarProvider) {
         this.pageProvider = pageProvider;
         this.ls = ls;
-        this.header = memoize(() -> new HeaderComponent(page().locator("header"), ls));
-        this.tabBar = memoize(() -> new TabBarComponent(page().locator("div.tab-bar__list"), ls));
+        this.headerProvider = headerProvider;
+        this.tabBarProvider = tabBarProvider;
     }
 
     protected Page page() {
@@ -30,29 +33,22 @@ public abstract class BasePage<T extends BasePage<T>> {
     }
 
     public HeaderComponent header() {
-        return header.get();
+        if (header == null) {
+            header = headerProvider.getObject(page().locator("header"));
+        }
+        return header;
     }
 
     public TabBarComponent tabBar() {
-        return tabBar.get();
+        if (tabBar == null) {
+            tabBar = tabBarProvider.getObject(page().locator("div.tab-bar__list"));
+        }
+        return tabBar;
     }
 
     @SuppressWarnings("unchecked")
     protected T self() {
         return (T) this;
-    }
-
-    private static <T> Supplier<T> memoize(Supplier<T> supplier) {
-        return new Supplier<>() {
-            private T value;
-            @Override
-            public T get() {
-                if (value == null) {
-                    value = supplier.get();
-                }
-                return value;
-            }
-        };
     }
 
     /**

--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -5,6 +5,8 @@ import com.example.testsupport.framework.localization.LocalizationService;
 import com.example.testsupport.framework.utils.Breakpoints;
 import com.example.testsupport.pages.components.FilterDrawerComponent;
 import com.example.testsupport.pages.components.AuthModalComponent;
+import com.example.testsupport.pages.components.HeaderComponent;
+import com.example.testsupport.pages.components.TabBarComponent;
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
@@ -24,8 +26,10 @@ import static com.example.testsupport.framework.utils.AllureHelper.step;
 public class CasinoPage extends BasePage<CasinoPage> {
     private final AppProperties props;
 
-    public CasinoPage(ObjectProvider<Page> page, AppProperties props, LocalizationService ls) {
-        super(page, ls);
+    public CasinoPage(ObjectProvider<Page> page, AppProperties props, LocalizationService ls,
+                      ObjectProvider<HeaderComponent> headerProvider,
+                      ObjectProvider<TabBarComponent> tabBarProvider) {
+        super(page, ls, headerProvider, tabBarProvider);
         this.props = props;
     }
 

--- a/src/test/java/com/example/testsupport/pages/MainPage.java
+++ b/src/test/java/com/example/testsupport/pages/MainPage.java
@@ -2,6 +2,8 @@ package com.example.testsupport.pages;
 
 import com.example.testsupport.framework.browser.PlaywrightManager;
 import com.example.testsupport.framework.localization.LocalizationService;
+import com.example.testsupport.pages.components.HeaderComponent;
+import com.example.testsupport.pages.components.TabBarComponent;
 import com.microsoft.playwright.Page;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -20,8 +22,10 @@ public class MainPage extends BasePage<MainPage> {
 
     public MainPage(ObjectProvider<Page> page, LocalizationService ls,
                     ObjectProvider<CasinoPage> casinoPageProvider,
-                    PlaywrightManager playwrightManager) {
-        super(page, ls);
+                    PlaywrightManager playwrightManager,
+                    ObjectProvider<HeaderComponent> headerProvider,
+                    ObjectProvider<TabBarComponent> tabBarProvider) {
+        super(page, ls, headerProvider, tabBarProvider);
         this.casinoPageProvider = casinoPageProvider;
         this.playwrightManager = playwrightManager;
     }

--- a/src/test/java/com/example/testsupport/pages/components/HeaderComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/HeaderComponent.java
@@ -3,12 +3,18 @@ package com.example.testsupport.pages.components;
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.options.AriaRole;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static com.example.testsupport.framework.utils.AllureHelper.step;
 
 /**
  * Header component for the desktop version.
  */
+@Component
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class HeaderComponent extends BaseComponent {
     private final LocalizationService ls;
 

--- a/src/test/java/com/example/testsupport/pages/components/TabBarComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/TabBarComponent.java
@@ -3,11 +3,17 @@ package com.example.testsupport.pages.components;
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.options.AriaRole;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
 import static com.example.testsupport.framework.utils.AllureHelper.step;
 
 /**
  * Tab bar component for the mobile version.
  */
+@Component
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class TabBarComponent extends BaseComponent {
     private final LocalizationService ls;
 

--- a/src/test/java/tests/BaseTest.java
+++ b/src/test/java/tests/BaseTest.java
@@ -5,6 +5,7 @@ import com.example.testsupport.framework.browser.PlaywrightManager;
 import com.example.testsupport.framework.device.Device;
 import com.example.testsupport.framework.listeners.PlaywrightExtension;
 import com.example.testsupport.framework.localization.LocalizationService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,13 +19,16 @@ public abstract class BaseTest {
     @Autowired protected PlaywrightManager playwrightManager;
     @Autowired protected LocalizationService ls;
 
+    @BeforeEach
     protected void setupTestEnvironment(Device device, String languageCode) {
-        step("Устанавливаем размер окна просмотра", () -> {
-            playwrightManager.getPage().setViewportSize(device.width(), device.height());
-        });
+        step(String.format("Подготовка тестового окружения [Устройство: %s, Язык: %s]", device, languageCode), () -> {
+            step("Устанавливаем размер окна просмотра", () -> {
+                playwrightManager.getPage().setViewportSize(device.width(), device.height());
+            });
 
-        step("Устанавливаем язык теста", () -> {
-            ls.loadLocale(languageCode);
+            step("Устанавливаем язык теста", () -> {
+                ls.loadLocale(languageCode);
+            });
         });
     }
 }

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -32,10 +32,6 @@ class MultilingualNavigationTest extends BaseTest {
         }
         final TestContext ctx = new TestContext();
 
-        step(String.format("Подготовка тестового окружения [Устройство: %s, Язык: %s]", device, languageCode), () -> {
-            setupTestEnvironment(device, languageCode);
-        });
-
         step("Открываем главную страницу", () -> {
             mainPage.open()
                     .verifyIsLoaded();


### PR DESCRIPTION
## Summary
- automate test environment setup with JUnit `@BeforeEach`
- simplify page object components using Spring `ObjectProvider`
- drop org.json in favor of Jackson for BrowserStack capabilities

## Testing
- `gradle test` *(fails: Failed to download Chromium for Playwright)*
- `gradle compileTestJava`


------
https://chatgpt.com/codex/tasks/task_e_68b1c95e1914832fa75450240f03cf02