### PR TITLE
feat: integrate openfeign api client for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,31 +14,47 @@ java {
 
 repositories { mavenCentral() }
 
-    dependencies {
-        implementation 'org.springframework.boot:spring-boot-starter'
-        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+dependencyManagement {
+    imports {
+        mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2023.0.3'
+    }
+}
 
-        // Needed for SpringExtension used in main test framework classes
-        implementation 'org.springframework:spring-test'
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-        implementation 'com.microsoft.playwright:playwright:1.48.0'
-        implementation 'org.json:json:20240303'
-        implementation 'com.fasterxml.jackson.core:jackson-databind'
-        implementation 'com.fasterxml.jackson.core:jackson-core'
+    // Needed for SpringExtension used in main test framework classes
+    implementation 'org.springframework:spring-test'
 
-        // JUnit API needed for main framework classes such as extensions
-        implementation platform('org.junit:junit-bom:5.10.0')
-        implementation 'org.junit.jupiter:junit-jupiter-api'
-        implementation 'org.junit.jupiter:junit-jupiter-params'
+    implementation 'com.microsoft.playwright:playwright:1.48.0'
+    implementation 'org.json:json:20240303'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.core:jackson-core'
 
-        // Allure commons used by framework utilities and listeners
-        implementation 'io.qameta.allure:allure-java-commons:2.29.0'
+    // OpenFeign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'io.github.openfeign:feign-okhttp'
 
-        testImplementation platform('org.junit:junit-bom:5.10.0')
-        testImplementation 'org.junit.jupiter:junit-jupiter'
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
-        testImplementation 'io.qameta.allure:allure-junit5:2.29.0'
-        testRuntimeOnly 'org.aspectj:aspectjweaver:1.9.22.1'
+    // JUnit API needed for main framework classes such as extensions
+    implementation platform('org.junit:junit-bom:5.10.0')
+    implementation 'org.junit.jupiter:junit-jupiter-api'
+    implementation 'org.junit.jupiter:junit-jupiter-params'
+
+    // Allure commons used by framework utilities and listeners
+    implementation 'io.qameta.allure:allure-java-commons:2.29.0'
+
+    testImplementation platform('org.junit:junit-bom:5.10.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+
+    testImplementation 'io.qameta.allure:allure-junit5:2.29.0'
+    testRuntimeOnly 'org.aspectj:aspectjweaver:1.9.22.1'
 }
 
 test {

--- a/src/main/java/com/example/testsupport/config/TestConfig.java
+++ b/src/main/java/com/example/testsupport/config/TestConfig.java
@@ -1,6 +1,7 @@
 package com.example.testsupport.config;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
@@ -9,5 +10,6 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration
 @EnableConfigurationProperties({AppProperties.class, BrowserStackProperties.class})
+@EnableFeignClients(basePackages = "com.example.testsupport.framework.api.client")
 @Import(PageConfig.class)
 public class TestConfig { }

--- a/src/main/java/com/example/testsupport/framework/api/attachment/AllureAttachmentService.java
+++ b/src/main/java/com/example/testsupport/framework/api/attachment/AllureAttachmentService.java
@@ -1,0 +1,39 @@
+package com.example.testsupport.framework.api.attachment;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.qameta.allure.Allure;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AllureAttachmentService {
+    private final ObjectMapper objectMapper;
+
+    public void attachJson(String name, Object data) {
+        if (data == null) {
+            Allure.addAttachment(name, "application/json", "null", ".json");
+            return;
+        }
+        try {
+            String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(data);
+            Allure.addAttachment(name, "application/json", json, ".json");
+        } catch (JsonProcessingException e) {
+            String content = "Failed to serialize to JSON: " + e.getMessage() + "\n\n" + data;
+            Allure.addAttachment(name, "text/plain", content, ".txt");
+        }
+    }
+
+    public void attachText(String name, String content) {
+        Allure.addAttachment(name, "text/plain", content, ".txt");
+    }
+
+    public void attachJson(AttachmentType type, String name, Object data) {
+        attachJson(type.getPrefix() + ": " + name, data);
+    }
+
+    public void attachText(AttachmentType type, String name, String content) {
+        attachText(type.getPrefix() + ": " + name, content);
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/api/attachment/AttachmentType.java
+++ b/src/main/java/com/example/testsupport/framework/api/attachment/AttachmentType.java
@@ -1,0 +1,19 @@
+package com.example.testsupport.framework.api.attachment;
+
+public enum AttachmentType {
+    HTTP("HTTP"),
+    KAFKA("Kafka"),
+    REDIS("Redis"),
+    DB("DB"),
+    NATS("NATS");
+
+    private final String prefix;
+
+    AttachmentType(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/api/client/FrontApiClient.java
+++ b/src/main/java/com/example/testsupport/framework/api/client/FrontApiClient.java
@@ -1,0 +1,8 @@
+package com.example.testsupport.framework.api.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+
+@FeignClient(name = "frontApiClient", url = "${app.api.base-url}")
+public interface FrontApiClient {
+}
+

--- a/src/main/java/com/example/testsupport/framework/api/config/AllureFeignLogger.java
+++ b/src/main/java/com/example/testsupport/framework/api/config/AllureFeignLogger.java
@@ -111,7 +111,8 @@ public class AllureFeignLogger extends Logger {
                     }
                     processedResponse = response.toBuilder().body(bodyData).build();
                 } else {
-                    processedResponse = response.toBuilder().body(null, (Integer) null).build();
+                    // No body to re-buffer; return the original response to avoid NPE
+                    processedResponse = response;
                 }
 
                 StringBuilder responseDetails = formatResponse(processedResponse, elapsedTime, bodyData, logLevel, false);

--- a/src/main/java/com/example/testsupport/framework/api/config/AllureFeignLogger.java
+++ b/src/main/java/com/example/testsupport/framework/api/config/AllureFeignLogger.java
@@ -1,0 +1,182 @@
+package com.example.testsupport.framework.api.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import feign.Logger;
+import feign.Request;
+import feign.Response;
+import feign.Util;
+import com.example.testsupport.framework.api.attachment.AllureAttachmentService;
+import com.example.testsupport.framework.api.attachment.AttachmentType;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+/**
+ * Feign logger that attaches request and response data to Allure reports.
+ */
+@Slf4j
+public class AllureFeignLogger extends Logger {
+    private final AllureAttachmentService attachmentService;
+
+    public AllureFeignLogger(AllureAttachmentService attachmentService) {
+        this.attachmentService = attachmentService;
+    }
+
+    private static final Set<String> IGNORED_REQUEST_HEADERS = new HashSet<>(Arrays.asList(
+            "accept", "content-type", "content-length", "host", "connection",
+            "accept-encoding", "user-agent", "transfer-encoding"
+    ));
+
+    @Override
+    protected void logRequest(String configKey, Level logLevel, Request request) {
+        try {
+            if (logLevel.ordinal() >= Level.HEADERS.ordinal()) {
+                StringBuilder requestDetails = formatRequest(request, logLevel, true);
+                attachmentService.attachText(AttachmentType.HTTP, "Request", requestDetails.toString());
+            }
+        } catch (Exception e) {
+            attachmentService.attachText(AttachmentType.HTTP, "Request Attachment Error", e.toString());
+        }
+    }
+
+    private StringBuilder formatRequest(Request request, Level logLevel, boolean filterHeaders) {
+        StringBuilder requestDetails = new StringBuilder();
+        requestDetails.append("Method: ").append(request.httpMethod().name()).append("\n");
+        requestDetails.append("Url: ").append(request.url()).append("\n");
+
+        if (logLevel.ordinal() >= Level.HEADERS.ordinal()) {
+            boolean headerSectionAdded = false;
+            for (Map.Entry<String, Collection<String>> entry : request.headers().entrySet()) {
+                String headerName = entry.getKey();
+                String headerNameLower = headerName.toLowerCase(Locale.ROOT);
+                if (!filterHeaders || !IGNORED_REQUEST_HEADERS.contains(headerNameLower)) {
+                    if (!headerSectionAdded) {
+                        requestDetails.append(filterHeaders ? "Custom Headers:\n" : "Headers:\n");
+                        headerSectionAdded = true;
+                    }
+                    requestDetails.append("  ").append(headerName).append(": ")
+                            .append(String.join("; ", entry.getValue())).append("\n");
+                }
+            }
+            if (filterHeaders && !headerSectionAdded && !request.headers().isEmpty()) {
+                requestDetails.append("Custom Headers: (none found or all filtered)\n");
+            } else if (!filterHeaders && !headerSectionAdded && !request.headers().isEmpty()) {
+                requestDetails.append("Headers: (present but listing failed?)\n");
+            }
+        }
+
+        if (request.body() != null && logLevel.ordinal() >= Level.FULL.ordinal()) {
+            requestDetails.append("Body:\n");
+            String bodyText = "[Binary Body or Unknown Charset]";
+            if (request.charset() != null) {
+                try {
+                    bodyText = new String(request.body(), request.charset());
+                } catch (Exception e) {
+                    bodyText = "[Binary Body - Decoding Failed]";
+                }
+            } else {
+                bodyText = new String(request.body(), StandardCharsets.UTF_8);
+            }
+            requestDetails.append(tryFormatJson(bodyText));
+        } else if (logLevel.ordinal() >= Level.FULL.ordinal()) {
+            requestDetails.append("Body: (empty)");
+        }
+        return requestDetails;
+    }
+
+    @Override
+    protected Response logAndRebufferResponse(String configKey, Level logLevel, Response response, long elapsedTime) throws IOException {
+        byte[] bodyData = {};
+        Response processedResponse = response;
+        Integer reportedLength = null;
+        try {
+            if (logLevel.ordinal() >= Level.HEADERS.ordinal()) {
+                Response.Body responseBody = response.body();
+                if (responseBody != null) {
+                    reportedLength = responseBody.length();
+                    if (reportedLength == null || reportedLength != 0) {
+                        try {
+                            bodyData = Util.toByteArray(responseBody.asInputStream());
+                            if (reportedLength != null && reportedLength > 0 && bodyData.length == 0)
+                                log.warn("[AllureFeignLogger][{}] !!! Body length reported as {}, but read 0 bytes!", configKey, reportedLength);
+                            else if (reportedLength != null && bodyData.length != reportedLength)
+                                log.warn("[AllureFeignLogger][{}] Body length reported as {}, but read {} bytes.", configKey, reportedLength, bodyData.length);
+                        } catch (IOException e) {
+                            throw e;
+                        } catch (Exception ignored) {
+                        }
+                    }
+                    processedResponse = response.toBuilder().body(bodyData).build();
+                } else {
+                    processedResponse = response.toBuilder().body(null, (Integer) null).build();
+                }
+
+                StringBuilder responseDetails = formatResponse(processedResponse, elapsedTime, bodyData, logLevel, false);
+                attachmentService.attachText(AttachmentType.HTTP, "Response", responseDetails.toString());
+            }
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            attachmentService.attachText(AttachmentType.HTTP, "Response Processing Error", e.toString());
+            if (response.body() != null) try { response.body().close(); } catch (IOException ignored) {}
+            throw new IOException("Unhandled exception during response processing: " + e.getMessage(), e);
+        }
+        return processedResponse;
+    }
+
+    private StringBuilder formatResponse(Response response, long elapsedTime, byte[] bodyData, Level logLevel, boolean includeHeaders) {
+        StringBuilder responseDetails = new StringBuilder();
+        int status = response.status();
+        String reason = response.reason() != null ? (" " + response.reason()) : "";
+        responseDetails.append("Status: ").append(status).append(reason).append("\n");
+        responseDetails.append("Time(ms): ").append(elapsedTime).append("\n");
+
+        if (includeHeaders && logLevel.ordinal() >= Level.HEADERS.ordinal()) {
+            responseDetails.append("Headers:\n");
+            for (Map.Entry<String, Collection<String>> entry : response.headers().entrySet()) {
+                responseDetails.append("  ").append(entry.getKey()).append(": ")
+                        .append(String.join("; ", entry.getValue())).append("\n");
+            }
+        }
+
+        if (logLevel.ordinal() >= Level.FULL.ordinal()) {
+            responseDetails.append("Body:\n");
+            if (bodyData.length > 0) {
+                String bodyText = new String(bodyData, StandardCharsets.UTF_8);
+                String formattedBody = tryFormatJson(bodyText);
+                responseDetails.append(formattedBody);
+            } else {
+                responseDetails.append("(empty)");
+            }
+        }
+        return responseDetails;
+    }
+
+    @Override
+    protected void log(String configKey, String format, Object... args) {
+        if (log.isDebugEnabled()) {
+            log.debug(String.format(methodTag(configKey) + format, args));
+        }
+    }
+
+    private String tryFormatJson(String text) {
+        if (text == null || text.isEmpty() || (!text.startsWith("{") && !text.startsWith("["))) {
+            return text;
+        }
+        try {
+            ObjectMapper mapper = LocalObjectMapperHolder.MAPPER;
+            Object jsonObject = mapper.readValue(text, Object.class);
+            return mapper.writeValueAsString(jsonObject);
+        } catch (Exception e) {
+            return text;
+        }
+    }
+
+    private static class LocalObjectMapperHolder {
+        static final ObjectMapper MAPPER = new ObjectMapper()
+                .enable(SerializationFeature.INDENT_OUTPUT);
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/api/config/AllureFeignLoggerConfig.java
+++ b/src/main/java/com/example/testsupport/framework/api/config/AllureFeignLoggerConfig.java
@@ -1,0 +1,43 @@
+package com.example.testsupport.framework.api.config;
+
+import feign.Client;
+import feign.Logger;
+import feign.okhttp.OkHttpClient;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.ConnectionPool;
+import org.springframework.cloud.openfeign.FeignBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import com.example.testsupport.framework.api.attachment.AllureAttachmentService;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@Slf4j
+public class AllureFeignLoggerConfig {
+
+    @Bean
+    Logger.Level feignLoggerLevel() {
+        return Logger.Level.FULL;
+    }
+
+    @Bean
+    public Client feignClient() {
+        okhttp3.OkHttpClient okHttpClient = new okhttp3.OkHttpClient.Builder()
+                .readTimeout(60, TimeUnit.SECONDS)
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .writeTimeout(60, TimeUnit.SECONDS)
+                .retryOnConnectionFailure(true)
+                .connectionPool(new ConnectionPool(10, 5, TimeUnit.MINUTES))
+                .build();
+
+        return new OkHttpClient(okHttpClient);
+    }
+
+    @Bean
+    public FeignBuilderCustomizer allureFeignLoggerCustomizer(Logger.Level feignLoggerLevel,
+                                                              AllureAttachmentService attachmentService) {
+        return builder -> builder.logger(new AllureFeignLogger(attachmentService))
+                .logLevel(feignLoggerLevel);
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/api/exceptions/HttpRequestFailedException.java
+++ b/src/main/java/com/example/testsupport/framework/api/exceptions/HttpRequestFailedException.java
@@ -1,0 +1,10 @@
+package com.example.testsupport.framework.api.exceptions;
+
+public class HttpRequestFailedException extends RuntimeException {
+    public HttpRequestFailedException(String message) {
+        super(message);
+    }
+    public HttpRequestFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/api/exceptions/HttpValidationException.java
+++ b/src/main/java/com/example/testsupport/framework/api/exceptions/HttpValidationException.java
@@ -1,0 +1,10 @@
+package com.example.testsupport.framework.api.exceptions;
+
+public class HttpValidationException extends RuntimeException {
+    public HttpValidationException(String message) {
+        super(message);
+    }
+    public HttpValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -2,3 +2,4 @@ spring.profiles.active=local
 app.browser=chromium
 app.language=lv
 app.api.base-url=https://spelet.lv
+spring.cloud.compatibility-verifier.enabled=false

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,4 @@
 spring.profiles.active=local
 app.browser=chromium
 app.language=lv
+app.api.base-url=https://spelet.lv

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,3 +4,7 @@ app:
   headless: false
   api:
     base-url: https://spelet.lv
+spring:
+  cloud:
+    compatibility-verifier:
+      enabled: false

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,3 +2,5 @@ app:
   base-url: https://spelet.lv
   browser: chromium
   headless: false
+  api:
+    base-url: https://spelet.lv


### PR DESCRIPTION
## Summary
- add Spring Cloud OpenFeign and Lombok dependencies
- introduce Allure-aware Feign logging and API client
- remove unused login helper and DTOs, rename to FrontApiClient

## Testing
- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 gradle test` *(fails: Failed to download Chromium 130.0.6723.31)*

------
https://chatgpt.com/codex/tasks/task_e_68b32bb0c188832fb8c02469aca100a4