### PR TITLE
refactor: simplify page and component DI

### DIFF
--- a/src/test/java/com/example/testsupport/pages/BasePage.java
+++ b/src/test/java/com/example/testsupport/pages/BasePage.java
@@ -4,7 +4,6 @@ import com.example.testsupport.config.AppProperties;
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.example.testsupport.pages.components.HeaderComponent;
 import com.example.testsupport.pages.components.TabBarComponent;
-import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.beans.factory.ObjectProvider;
@@ -13,27 +12,23 @@ import org.springframework.beans.factory.ObjectProvider;
  * Base Page Object with shared logic.
  */
 public abstract class BasePage<T extends BasePage<T>> {
-    private final ObjectProvider<Page> pageProvider;
+    protected final Page page;
     protected final LocalizationService ls;
     protected final AppProperties props;
     private final HeaderComponent header;
     private final TabBarComponent tabBar;
-    private final Locator headerRoot;
-    private final Locator tabBarRoot;
 
     @SuppressWarnings("resource")
-    protected BasePage(ObjectProvider<Page> pageProvider, LocalizationService ls, AppProperties props) {
-        this.pageProvider = pageProvider;
+    protected BasePage(Page page,
+                       LocalizationService ls,
+                       AppProperties props,
+                       ObjectProvider<HeaderComponent> headerProvider,
+                       ObjectProvider<TabBarComponent> tabBarProvider) {
+        this.page = page;
         this.ls = ls;
         this.props = props;
-        this.headerRoot = page().locator("header");
-        this.tabBarRoot = page().locator("div.tab-bar__list");
-        this.header = new HeaderComponent(headerRoot, ls);
-        this.tabBar = new TabBarComponent(tabBarRoot, ls);
-    }
-
-    protected Page page() {
-        return pageProvider.getObject();
+        this.header = headerProvider.getObject();
+        this.tabBar = tabBarProvider.getObject();
     }
 
     public HeaderComponent header() {
@@ -58,12 +53,12 @@ public abstract class BasePage<T extends BasePage<T>> {
     }
 
     public T open() {
-        page().navigate(buildBaseUrlForCurrentLanguage());
+        page.navigate(buildBaseUrlForCurrentLanguage());
         return self();
     }
 
     public T navigate(String path) {
-        page().navigate(buildBaseUrlForCurrentLanguage() + path);
+        page.navigate(buildBaseUrlForCurrentLanguage() + path);
         return self();
     }
 
@@ -73,7 +68,7 @@ public abstract class BasePage<T extends BasePage<T>> {
      * @param expectedPath expected URL substring
      */
     public void verifyUrlContains(String expectedPath) {
-        String current = page().url();
+        String current = page.url();
         Assertions.assertTrue(
                 current.contains(expectedPath),
                 String.format("Expected URL to contain '%s' but was '%s'", expectedPath, current)

--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -5,6 +5,8 @@ import com.example.testsupport.framework.localization.LocalizationService;
 import com.example.testsupport.framework.utils.Breakpoints;
 import com.example.testsupport.pages.components.FilterDrawerComponent;
 import com.example.testsupport.pages.components.AuthModalComponent;
+import com.example.testsupport.pages.components.HeaderComponent;
+import com.example.testsupport.pages.components.TabBarComponent;
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
@@ -26,22 +28,27 @@ public class CasinoPage extends BasePage<CasinoPage> {
 
     private final Locator mobileFilterButton;
     private final Locator desktopFilterButton;
-    private final Locator filterDrawerRoot;
     private final Locator searchInput;
     private final Locator gameCards;
-    private final Locator authDialog;
+    private final ObjectProvider<FilterDrawerComponent> filterDrawerComponentProvider;
+    private final ObjectProvider<AuthModalComponent> authModalComponentProvider;
 
-    public CasinoPage(ObjectProvider<Page> page, AppProperties props, LocalizationService ls) {
-        super(page, ls, props);
-        this.mobileFilterButton = page().locator("div.d_block.pos_relative.w768\\:d_none > button");
+    public CasinoPage(Page page,
+                      AppProperties props,
+                      LocalizationService ls,
+                      ObjectProvider<FilterDrawerComponent> filterDrawerComponentProvider,
+                      ObjectProvider<AuthModalComponent> authModalComponentProvider,
+                      ObjectProvider<HeaderComponent> headerProvider,
+                      ObjectProvider<TabBarComponent> tabBarProvider) {
+        super(page, ls, props, headerProvider, tabBarProvider);
+        this.filterDrawerComponentProvider = filterDrawerComponentProvider;
+        this.authModalComponentProvider = authModalComponentProvider;
+        this.mobileFilterButton = page.locator("div.d_block.pos_relative.w768\\:d_none > button");
         String buttonText = ls.get("casino.filters.button");
-        this.desktopFilterButton = page().getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName(buttonText).setExact(true));
-        this.filterDrawerRoot = page().locator("div.drawer__headerWrapper").locator("..");
+        this.desktopFilterButton = page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName(buttonText).setExact(true));
         String searchLabel = ls.get("casino.search.input");
-        this.searchInput = page().getByRole(AriaRole.SEARCHBOX, new Page.GetByRoleOptions().setName(searchLabel).setExact(true));
-        this.gameCards = page().locator(".GameCard__root");
-        String promptTitle = ls.get("casino.play.prompt");
-        this.authDialog = page().getByText(promptTitle, new Page.GetByTextOptions().setExact(true)).locator("..");
+        this.searchInput = page.getByRole(AriaRole.SEARCHBOX, new Page.GetByRoleOptions().setName(searchLabel).setExact(true));
+        this.gameCards = page.locator(".GameCard__root");
     }
 
     /**
@@ -89,14 +96,14 @@ public class CasinoPage extends BasePage<CasinoPage> {
     public FilterDrawerComponent openFilters() {
         return step("Открытие панели фильтров", () -> {
             Locator button;
-            int width = page().viewportSize() != null ? page().viewportSize().width : Integer.MAX_VALUE;
+            int width = page.viewportSize() != null ? page.viewportSize().width : Integer.MAX_VALUE;
             if (width < Breakpoints.TABLET) {
                 button = mobileFilterButton;
             } else {
                 button = desktopFilterButton;
             }
             button.click();
-            return new FilterDrawerComponent(filterDrawerRoot, ls, this);
+            return filterDrawerComponentProvider.getObject();
         });
     }
 
@@ -137,7 +144,7 @@ public class CasinoPage extends BasePage<CasinoPage> {
         return step(String.format("Запускаем игру '%s'", gameName), () -> {
             Locator card = gameCards.filter(new Locator.FilterOptions().setHasText(gameName)).first();
             card.getByRole(AriaRole.BUTTON).click();
-            return new AuthModalComponent(authDialog, ls);
+            return authModalComponentProvider.getObject();
         });
     }
 }

--- a/src/test/java/com/example/testsupport/pages/MainPage.java
+++ b/src/test/java/com/example/testsupport/pages/MainPage.java
@@ -2,6 +2,8 @@ package com.example.testsupport.pages;
 
 import com.example.testsupport.config.AppProperties;
 import com.example.testsupport.framework.localization.LocalizationService;
+import com.example.testsupport.pages.components.HeaderComponent;
+import com.example.testsupport.pages.components.TabBarComponent;
 import com.microsoft.playwright.Page;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -17,11 +19,13 @@ public class MainPage extends BasePage<MainPage> {
 
     private final ObjectProvider<CasinoPage> casinoPageProvider;
 
-    public MainPage(ObjectProvider<Page> page,
+    public MainPage(Page page,
                     LocalizationService ls,
                     ObjectProvider<CasinoPage> casinoPageProvider,
-                    AppProperties props) {
-        super(page, ls, props);
+                    AppProperties props,
+                    ObjectProvider<HeaderComponent> headerProvider,
+                    ObjectProvider<TabBarComponent> tabBarProvider) {
+        super(page, ls, props, headerProvider, tabBarProvider);
         this.casinoPageProvider = casinoPageProvider;
     }
 
@@ -31,13 +35,13 @@ public class MainPage extends BasePage<MainPage> {
     @SuppressWarnings("resource")
     public CasinoPage navigateToCasino() {
         return step("Навигация на страницу 'Казино'", () -> {
-            int currentWidth = page().viewportSize().width;
+            int currentWidth = page.viewportSize().width;
             if (currentWidth < MOBILE) {
                 tabBar().clickCasino();
             } else {
                 header().clickCasino();
             }
-            step("Ожидание URL страницы 'Казино'", () -> page().waitForURL("**/casino"));
+            step("Ожидание URL страницы 'Казино'", () -> page.waitForURL("**/casino"));
             return casinoPageProvider.getObject().verifyIsLoaded();
         });
     }

--- a/src/test/java/com/example/testsupport/pages/components/AuthModalComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/AuthModalComponent.java
@@ -2,6 +2,10 @@ package com.example.testsupport.pages.components;
 
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static com.example.testsupport.framework.utils.AllureHelper.step;
@@ -10,16 +14,16 @@ import static com.example.testsupport.framework.utils.AllureHelper.step;
  * Component representing the authorization prompt modal that appears when
  * attempting to launch a game without being logged in.
  */
+@Component
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class AuthModalComponent extends BaseComponent {
 
     private final Locator title;
-    private final LocalizationService ls;
 
-    public AuthModalComponent(Locator root, LocalizationService ls) {
-        super(root);
-        this.ls = ls;
+    public AuthModalComponent(Page page, LocalizationService ls) {
+        super(page.getByText(ls.get("casino.play.prompt"), new Page.GetByTextOptions().setExact(true)).locator(".."));
         String titleText = ls.get("casino.play.prompt");
-        this.title = root.getByText(titleText, new Locator.GetByTextOptions().setExact(true));
+        this.title = root().getByText(titleText, new Locator.GetByTextOptions().setExact(true));
     }
 
     /**

--- a/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
@@ -3,7 +3,12 @@ package com.example.testsupport.pages.components;
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.example.testsupport.pages.CasinoPage;
 import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static com.example.testsupport.framework.utils.AllureHelper.step;
@@ -11,21 +16,23 @@ import static com.example.testsupport.framework.utils.AllureHelper.step;
 /**
  * Component representing the filter drawer on the casino page.
  */
+@Component
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class FilterDrawerComponent extends BaseComponent {
 
-    private final LocalizationService ls;
-    private final CasinoPage casinoPage;
+    private final ObjectProvider<CasinoPage> casinoPageProvider;
     private final Locator title;
     private final Locator showButton;
 
-    public FilterDrawerComponent(Locator root, LocalizationService ls, CasinoPage casinoPage) {
-        super(root);
-        this.ls = ls;
-        this.casinoPage = casinoPage;
+    public FilterDrawerComponent(Page page,
+                                 LocalizationService ls,
+                                 ObjectProvider<CasinoPage> casinoPageProvider) {
+        super(page.locator("div.drawer__headerWrapper").locator(".."));
+        this.casinoPageProvider = casinoPageProvider;
         String titleText = ls.get("casino.filters.title");
-        this.title = root.getByRole(AriaRole.HEADING, new Locator.GetByRoleOptions().setName(titleText).setExact(true));
+        this.title = root().getByRole(AriaRole.HEADING, new Locator.GetByRoleOptions().setName(titleText).setExact(true));
         String showText = ls.get("casino.filters.show");
-        this.showButton = root.getByRole(AriaRole.BUTTON, new Locator.GetByRoleOptions().setName(showText).setExact(true));
+        this.showButton = root().getByRole(AriaRole.BUTTON, new Locator.GetByRoleOptions().setName(showText).setExact(true));
     }
 
     /**
@@ -48,7 +55,7 @@ public class FilterDrawerComponent extends BaseComponent {
      */
     public FilterDrawerComponent selectProvider(String providerName) {
         return step(String.format("Выбор провайдера '%s'", providerName), () -> {
-            root.getByRole(AriaRole.ROW, new Locator.GetByRoleOptions()
+            root().getByRole(AriaRole.ROW, new Locator.GetByRoleOptions()
                     .setName(providerName)
                     .setExact(true))
                 .click();
@@ -62,7 +69,7 @@ public class FilterDrawerComponent extends BaseComponent {
     public CasinoPage clickShow() {
         return step("Применение фильтров", () -> {
             showButton.click();
-            return casinoPage;
+            return casinoPageProvider.getObject();
         });
     }
 }

--- a/src/test/java/com/example/testsupport/pages/components/HeaderComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/HeaderComponent.java
@@ -2,7 +2,11 @@ package com.example.testsupport.pages.components;
 
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static com.example.testsupport.framework.utils.AllureHelper.step;
@@ -10,17 +14,17 @@ import static com.example.testsupport.framework.utils.AllureHelper.step;
 /**
  * Header component for the desktop version.
  */
+@Component
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class HeaderComponent extends BaseComponent {
     private final Locator casinoLink;
     private final Locator logoLink;
-    private final LocalizationService ls;
 
-    public HeaderComponent(Locator root, LocalizationService ls) {
-        super(root);
-        this.ls = ls;
+    public HeaderComponent(Page page, LocalizationService ls) {
+        super(page.locator("header"));
         String casinoText = ls.get("header.menu.casino");
-        this.casinoLink = root.getByRole(AriaRole.LINK, new Locator.GetByRoleOptions().setName(casinoText).setExact(true));
-        this.logoLink = root.getByRole(AriaRole.LINK, new Locator.GetByRoleOptions().setName("Spelet"));
+        this.casinoLink = root().getByRole(AriaRole.LINK, new Locator.GetByRoleOptions().setName(casinoText).setExact(true));
+        this.logoLink = root().getByRole(AriaRole.LINK, new Locator.GetByRoleOptions().setName("Spelet"));
     }
 
     /**

--- a/src/test/java/com/example/testsupport/pages/components/TabBarComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/TabBarComponent.java
@@ -2,22 +2,28 @@ package com.example.testsupport.pages.components;
 
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 
 import static com.example.testsupport.framework.utils.AllureHelper.step;
 
 /**
  * Tab bar component for the mobile version.
  */
+@Component
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 public class TabBarComponent extends BaseComponent {
     private final Locator casinoTab;
     private final Locator profileTab;
 
-    public TabBarComponent(Locator root, LocalizationService ls) {
-        super(root);
+    public TabBarComponent(Page page, LocalizationService ls) {
+        super(page.locator("div.tab-bar__list"));
         String casinoText = ls.get("header.menu.casino");
-        this.casinoTab = root.getByRole(AriaRole.TAB, new Locator.GetByRoleOptions().setName(casinoText).setExact(true));
-        this.profileTab = root.getByRole(AriaRole.TAB, new Locator.GetByRoleOptions().setName("Profile"));
+        this.casinoTab = root().getByRole(AriaRole.TAB, new Locator.GetByRoleOptions().setName(casinoText).setExact(true));
+        this.profileTab = root().getByRole(AriaRole.TAB, new Locator.GetByRoleOptions().setName("Profile"));
     }
 
     /**


### PR DESCRIPTION
## Summary
- inject Playwright Page directly into BasePage and descendants
- convert UI components to prototype-scoped Spring beans
- obtain components via ObjectProvider instead of manual construction

## Testing
- `gradle test` *(fails: Execution failed for task ':test'. There were failing tests, ERR_SOCKET_CLOSED)*


------
https://chatgpt.com/codex/tasks/task_e_68b35009f8a4832f946e9605d84d786c