### PR TITLE
Force UTF-8 encoding for test tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,3 +171,9 @@ browserStackConfigs.each { taskName, props ->
         dependsOn(playwrightInstall)
     }
 }
+
+// Ensure UTF-8 encoding for all test JVMs
+tasks.withType(Test).configureEach {
+    jvmArgs '-Dfile.encoding=UTF-8'
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,6 @@ browserStackConfigs.each { taskName, props ->
 
 // Ensure UTF-8 encoding for all test JVMs
 tasks.withType(Test).configureEach {
-    jvmArgs '-Dfile.encoding=UTF-8'
+    systemProperty 'file.encoding', 'UTF-8'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Dfile.encoding=UTF-8


### PR DESCRIPTION
## Summary
- Configure all Gradle `Test` tasks to start JVMs with `file.encoding=UTF-8` for proper Cyrillic output in console logs.

## Testing
- `gradle test` *(fails: Failed to download Chromium during `playwrightInstall`)*

------
https://chatgpt.com/codex/tasks/task_e_68b36af5a060832f8effe9bd6d4e8597