### PR TITLE
Add generic Feign params interceptor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,10 @@ test {
     }
 }
 
+tasks.withType(Test).configureEach {
+    jvmArgs '-Dfile.encoding=UTF-8', '--add-opens=java.base/java.lang=ALL-UNNAMED'
+}
+
 tasks.register('playwrightInstall', JavaExec) {
     group = 'verification'
     description = 'Install Playwright browsers'

--- a/src/main/java/com/example/testsupport/framework/api/client/GenericParamsInterceptor.java
+++ b/src/main/java/com/example/testsupport/framework/api/client/GenericParamsInterceptor.java
@@ -15,12 +15,10 @@ public class GenericParamsInterceptor implements RequestInterceptor {
 
     @Override
     public void apply(RequestTemplate template) {
-        Collection<?> paramsCollection = template.queries().get("params");
+        Collection<?> paramsCollection = template.queries().remove("params");
         if (paramsCollection == null || paramsCollection.isEmpty()) {
             return;
         }
-        // remove technical "params" query parameter
-        template.query("params", (String) null);
         Object params = paramsCollection.iterator().next();
         for (Field field : params.getClass().getDeclaredFields()) {
             field.setAccessible(true);

--- a/src/main/java/com/example/testsupport/framework/api/client/GenericParamsInterceptor.java
+++ b/src/main/java/com/example/testsupport/framework/api/client/GenericParamsInterceptor.java
@@ -6,6 +6,8 @@ import feign.RequestInterceptor;
 import feign.RequestTemplate;
 import java.lang.reflect.Field;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Generic interceptor that maps annotated fields of parameter objects to
@@ -15,11 +17,19 @@ public class GenericParamsInterceptor implements RequestInterceptor {
 
     @Override
     public void apply(RequestTemplate template) {
-        Collection<?> paramsCollection = template.queries().remove("params");
-        if (paramsCollection == null || paramsCollection.isEmpty()) {
+        if (!template.queries().containsKey("params")) {
             return;
         }
+
+        Collection<?> paramsCollection = template.queries().get("params");
+        if (paramsCollection == null || paramsCollection.isEmpty()) {
+            clearParamsQuery(template);
+            return;
+        }
+
         Object params = paramsCollection.iterator().next();
+        clearParamsQuery(template);
+
         for (Field field : params.getClass().getDeclaredFields()) {
             field.setAccessible(true);
             try {
@@ -39,5 +49,11 @@ public class GenericParamsInterceptor implements RequestInterceptor {
                 // ignore inaccessible field
             }
         }
+    }
+
+    private void clearParamsQuery(RequestTemplate template) {
+        Map<String, Collection<String>> queries = new LinkedHashMap<>(template.queries());
+        queries.remove("params");
+        template.queries(queries);
     }
 }

--- a/src/main/java/com/example/testsupport/framework/api/client/GenericParamsInterceptor.java
+++ b/src/main/java/com/example/testsupport/framework/api/client/GenericParamsInterceptor.java
@@ -15,10 +15,12 @@ public class GenericParamsInterceptor implements RequestInterceptor {
 
     @Override
     public void apply(RequestTemplate template) {
-        Collection<?> paramsCollection = (Collection<?>) template.queries().remove("params");
+        Collection<?> paramsCollection = template.queries().get("params");
         if (paramsCollection == null || paramsCollection.isEmpty()) {
             return;
         }
+        // remove technical "params" query parameter
+        template.query("params", (String) null);
         Object params = paramsCollection.iterator().next();
         for (Field field : params.getClass().getDeclaredFields()) {
             field.setAccessible(true);

--- a/src/main/java/com/example/testsupport/framework/api/client/GenericParamsInterceptor.java
+++ b/src/main/java/com/example/testsupport/framework/api/client/GenericParamsInterceptor.java
@@ -1,0 +1,43 @@
+package com.example.testsupport.framework.api.client;
+
+import com.example.testsupport.framework.api.client.annotations.RequestHeaderParam;
+import com.example.testsupport.framework.api.client.annotations.RequestQueryParam;
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import java.lang.reflect.Field;
+import java.util.Collection;
+
+/**
+ * Generic interceptor that maps annotated fields of parameter objects to
+ * request query parameters and headers.
+ */
+public class GenericParamsInterceptor implements RequestInterceptor {
+
+    @Override
+    public void apply(RequestTemplate template) {
+        Collection<?> paramsCollection = (Collection<?>) template.queries().remove("params");
+        if (paramsCollection == null || paramsCollection.isEmpty()) {
+            return;
+        }
+        Object params = paramsCollection.iterator().next();
+        for (Field field : params.getClass().getDeclaredFields()) {
+            field.setAccessible(true);
+            try {
+                Object value = field.get(params);
+                if (value == null) {
+                    continue;
+                }
+                RequestQueryParam queryAnn = field.getAnnotation(RequestQueryParam.class);
+                if (queryAnn != null) {
+                    template.query(queryAnn.value(), value.toString());
+                }
+                RequestHeaderParam headerAnn = field.getAnnotation(RequestHeaderParam.class);
+                if (headerAnn != null) {
+                    template.header(headerAnn.value(), value.toString());
+                }
+            } catch (IllegalAccessException ignored) {
+                // ignore inaccessible field
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/api/client/GenericParamsInterceptor.java
+++ b/src/main/java/com/example/testsupport/framework/api/client/GenericParamsInterceptor.java
@@ -55,5 +55,7 @@ public class GenericParamsInterceptor implements RequestInterceptor {
         Map<String, Collection<String>> queries = new LinkedHashMap<>(template.queries());
         queries.remove("params");
         template.queries(queries);
+        // Remove any body accidentally created for GET requests
+        template.body((String) null);
     }
 }

--- a/src/main/java/com/example/testsupport/framework/api/client/GenericParamsInterceptor.java
+++ b/src/main/java/com/example/testsupport/framework/api/client/GenericParamsInterceptor.java
@@ -55,7 +55,5 @@ public class GenericParamsInterceptor implements RequestInterceptor {
         Map<String, Collection<String>> queries = new LinkedHashMap<>(template.queries());
         queries.remove("params");
         template.queries(queries);
-        // Remove any body accidentally created for GET requests
-        template.body((String) null);
     }
 }

--- a/src/main/java/com/example/testsupport/framework/api/client/annotations/RequestHeaderParam.java
+++ b/src/main/java/com/example/testsupport/framework/api/client/annotations/RequestHeaderParam.java
@@ -1,0 +1,12 @@
+package com.example.testsupport.framework.api.client.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface RequestHeaderParam {
+    String value();
+}

--- a/src/main/java/com/example/testsupport/framework/api/client/annotations/RequestQueryParam.java
+++ b/src/main/java/com/example/testsupport/framework/api/client/annotations/RequestQueryParam.java
@@ -1,0 +1,12 @@
+package com.example.testsupport.framework.api.client.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface RequestQueryParam {
+    String value();
+}

--- a/src/test/java/com/example/testsupport/framework/api/client/FrontApiClient.java
+++ b/src/test/java/com/example/testsupport/framework/api/client/FrontApiClient.java
@@ -2,14 +2,14 @@ package com.example.testsupport.framework.api.client;
 
 import com.example.testsupport.framework.api.client.params.GamblingBrandsParams;
 import com.example.testsupport.framework.api.dto.gambling.GamblingBrandsResponse;
-import feign.Param;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "frontApiClient", url = "${env.api.base-url}", configuration = GenericParamsInterceptor.class)
 public interface FrontApiClient {
 
     @GetMapping("/_front_api/api/v1/gambling/brands")
-    GamblingBrandsResponse getGamblingBrands(@Param("params") GamblingBrandsParams params);
+    GamblingBrandsResponse getGamblingBrands(@RequestParam("params") GamblingBrandsParams params);
 }
 

--- a/src/test/java/com/example/testsupport/framework/api/client/FrontApiClient.java
+++ b/src/test/java/com/example/testsupport/framework/api/client/FrontApiClient.java
@@ -2,7 +2,7 @@ package com.example.testsupport.framework.api.client;
 
 import com.example.testsupport.framework.api.client.params.GamblingBrandsParams;
 import com.example.testsupport.framework.api.dto.gambling.GamblingBrandsResponse;
-import org.springframework.web.bind.annotation.RequestParam;
+import feign.Param;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 
@@ -10,6 +10,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 public interface FrontApiClient {
 
     @GetMapping("/_front_api/api/v1/gambling/brands")
-    GamblingBrandsResponse getGamblingBrands(@RequestParam("params") GamblingBrandsParams params);
+    GamblingBrandsResponse getGamblingBrands(@Param("params") GamblingBrandsParams params);
 }
 

--- a/src/test/java/com/example/testsupport/framework/api/client/FrontApiClient.java
+++ b/src/test/java/com/example/testsupport/framework/api/client/FrontApiClient.java
@@ -1,8 +1,15 @@
 package com.example.testsupport.framework.api.client;
 
+import com.example.testsupport.framework.api.client.params.GamblingBrandsParams;
+import com.example.testsupport.framework.api.dto.gambling.GamblingBrandsResponse;
+import feign.Param;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
 
-@FeignClient(name = "frontApiClient", url = "${env.api.base-url}")
+@FeignClient(name = "frontApiClient", url = "${env.api.base-url}", configuration = GenericParamsInterceptor.class)
 public interface FrontApiClient {
+
+    @GetMapping("/_front_api/api/v1/gambling/brands")
+    GamblingBrandsResponse getGamblingBrands(@Param("params") GamblingBrandsParams params);
 }
 

--- a/src/test/java/com/example/testsupport/framework/api/client/FrontApiClient.java
+++ b/src/test/java/com/example/testsupport/framework/api/client/FrontApiClient.java
@@ -2,7 +2,7 @@ package com.example.testsupport.framework.api.client;
 
 import com.example.testsupport.framework.api.client.params.GamblingBrandsParams;
 import com.example.testsupport.framework.api.dto.gambling.GamblingBrandsResponse;
-import feign.Param;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 
@@ -10,6 +10,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 public interface FrontApiClient {
 
     @GetMapping("/_front_api/api/v1/gambling/brands")
-    GamblingBrandsResponse getGamblingBrands(@Param("params") GamblingBrandsParams params);
+    GamblingBrandsResponse getGamblingBrands(@RequestParam("params") GamblingBrandsParams params);
 }
 

--- a/src/test/java/com/example/testsupport/framework/api/client/params/GamblingBrandsParams.java
+++ b/src/test/java/com/example/testsupport/framework/api/client/params/GamblingBrandsParams.java
@@ -1,0 +1,26 @@
+package com.example.testsupport.framework.api.client.params;
+
+import com.example.testsupport.framework.api.client.annotations.RequestHeaderParam;
+import com.example.testsupport.framework.api.client.annotations.RequestQueryParam;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GamblingBrandsParams {
+
+    @RequestHeaderParam("Platform-NodeId")
+    private String platformNodeId;
+
+    @RequestHeaderParam("Platform-Locale")
+    private String platformLocale;
+
+    @RequestQueryParam("deviceType")
+    private String deviceType;
+
+    @RequestQueryParam("showRestricted")
+    private Boolean showRestricted;
+
+    @RequestQueryParam("categoryAlias")
+    private String categoryAlias;
+}

--- a/src/test/java/com/example/testsupport/framework/api/dto/gambling/Brand.java
+++ b/src/test/java/com/example/testsupport/framework/api/dto/gambling/Brand.java
@@ -1,0 +1,11 @@
+package com.example.testsupport.framework.api.dto.gambling;
+
+public record Brand(
+    String id,
+    String name,
+    String alias,
+    String icon,
+    String logo,
+    String colorLogo
+) {}
+

--- a/src/test/java/com/example/testsupport/framework/api/dto/gambling/GamblingBrandsResponse.java
+++ b/src/test/java/com/example/testsupport/framework/api/dto/gambling/GamblingBrandsResponse.java
@@ -1,0 +1,6 @@
+package com.example.testsupport.framework.api.dto.gambling;
+
+import java.util.List;
+
+public record GamblingBrandsResponse(List<Brand> brands) {}
+

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -12,6 +12,9 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import com.example.testsupport.framework.api.client.FrontApiClient;
+import com.example.testsupport.framework.api.client.params.GamblingBrandsParams;
+import com.example.testsupport.framework.api.dto.gambling.GamblingBrandsResponse;
 
 import static com.example.testsupport.framework.utils.AllureHelper.step;
 
@@ -19,6 +22,7 @@ import static com.example.testsupport.framework.utils.AllureHelper.step;
 @Feature("Навигация по шапке")
 class MultilingualNavigationTest extends BaseTest {
     @Autowired private ObjectProvider<MainPage> mainPageProvider;
+    @Autowired private FrontApiClient frontApiClient;
 
     @Story("Переход на страницу казино для всех поддерживаемых языков и устройств")
     @DisplayName("Навигация на страницу казино")
@@ -32,6 +36,16 @@ class MultilingualNavigationTest extends BaseTest {
             AuthModalComponent authModal;
         }
         final TestContext ctx = new TestContext();
+
+        step("Получаем список брендов через API", () -> {
+            GamblingBrandsResponse response = frontApiClient.getGamblingBrands(
+                    GamblingBrandsParams.builder().build()
+            );
+            Assertions.assertFalse(response.brands().isEmpty(), "Список брендов пуст");
+            Assertions.assertTrue(
+                    response.brands().stream().anyMatch(b -> "Play'n Go".equals(b.name())),
+                    "Бренд 'Play'n Go' отсутствует");
+        });
 
         step(String.format("Подготовка тестового окружения [Устройство: %s, Язык: %s]", device, languageCode), () -> {
             setupTestEnvironment(device, languageCode);


### PR DESCRIPTION
## Summary
- add `@RequestQueryParam` and `@RequestHeaderParam` for declarative query/header mapping
- implement `GenericParamsInterceptor` to apply annotated params to requests
- introduce `GamblingBrandsParams` and refactor `FrontApiClient` to use the new interceptor
- move generic interceptor and related annotations to main source set for reuse

## Testing
- `gradle test`: ❌ Failed to install Playwright browsers


------
https://chatgpt.com/codex/tasks/task_e_68b40092f820832fbe76dd61c0de51e9