### PR TITLE
feat: allow custom suite names in Allure

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,10 @@ env:
 
 To create a new environment, add `application-myenv.yml` and run tests with
 `-Dspring.profiles.active=myenv`.
+
+## 🧩 Custom suite names in Allure
+
+Annotate test classes or methods with `@Suite("Human readable name")` to set a
+clear, business-oriented suite name in the Allure report. When both class and
+method are annotated, the method-level value takes precedence. Tests without the
+annotation continue to use the default class name.

--- a/src/main/java/com/example/testsupport/framework/allure/CustomSuiteExtension.java
+++ b/src/main/java/com/example/testsupport/framework/allure/CustomSuiteExtension.java
@@ -1,0 +1,28 @@
+package com.example.testsupport.framework.allure;
+
+import io.qameta.allure.Allure;
+import io.qameta.allure.model.Label;
+import java.util.Optional;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class CustomSuiteExtension implements BeforeTestExecutionCallback {
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context) {
+        Suite suite = resolveSuite(context);
+        if (suite == null) {
+            return;
+        }
+        Allure.getLifecycle().updateTestCase(tc -> tc.getLabels().removeIf(l -> "suite".equals(l.getName())));
+        Allure.getLifecycle().updateTestCase(tc -> tc.getLabels().add(new Label().setName("suite").setValue(suite.value())));
+    }
+
+    private Suite resolveSuite(ExtensionContext context) {
+        Optional<Suite> methodSuite = context.getTestMethod().map(m -> m.getAnnotation(Suite.class));
+        if (methodSuite.isPresent()) {
+            return methodSuite.get();
+        }
+        return context.getTestClass().map(c -> c.getAnnotation(Suite.class)).orElse(null);
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/allure/Suite.java
+++ b/src/main/java/com/example/testsupport/framework/allure/Suite.java
@@ -1,0 +1,12 @@
+package com.example.testsupport.framework.allure;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Suite {
+    String value();
+}

--- a/src/test/java/tests/BaseTest.java
+++ b/src/test/java/tests/BaseTest.java
@@ -5,6 +5,7 @@ import com.example.testsupport.framework.browser.PlaywrightManager;
 import com.example.testsupport.framework.device.Device;
 import com.example.testsupport.framework.listeners.PlaywrightExtension;
 import com.example.testsupport.framework.localization.LocalizationService;
+import com.example.testsupport.framework.allure.CustomSuiteExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,7 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import static com.example.testsupport.framework.utils.AllureHelper.step;
 
 @SpringBootTest(classes = TestApplication.class)
-@ExtendWith(PlaywrightExtension.class)
+@ExtendWith({PlaywrightExtension.class, CustomSuiteExtension.class})
 public abstract class BaseTest {
 
     @Autowired protected PlaywrightManager playwrightManager;

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -15,11 +15,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.example.testsupport.framework.api.client.FrontApiClient;
 import com.example.testsupport.framework.api.client.params.GamblingBrandsParams;
 import com.example.testsupport.framework.api.dto.gambling.GamblingBrandsResponse;
+import com.example.testsupport.framework.allure.Suite;
 
 import static com.example.testsupport.framework.utils.AllureHelper.step;
 
 @Epic("Spelet.lv")
 @Feature("Навигация по шапке")
+@Suite("Навигация и базовый флоу казино")
 class MultilingualNavigationTest extends BaseTest {
     @Autowired private ObjectProvider<MainPage> mainPageProvider;
     @Autowired private FrontApiClient frontApiClient;


### PR DESCRIPTION
## Summary
- add `@Suite` annotation and JUnit extension to override Allure suite names
- register custom extension for all tests via `BaseTest`
- document custom suite naming and apply to MultilingualNavigationTest

## Testing
- `gradle test` *(fails: Failed to download Chromium 130.0.6723.31)*

------
https://chatgpt.com/codex/tasks/task_e_68b4212180f8832fac7616053608ce3b