### PR TITLE
refactor: move retry annotations and extensions to main

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
     testImplementation 'io.qameta.allure:allure-junit5:2.29.0'
-    testImplementation 'io.github.artsok:rerunner-jupiter:2.1.6'
+    implementation 'io.github.artsok:rerunner-jupiter:2.1.6'
     testRuntimeOnly 'org.aspectj:aspectjweaver:1.9.22.1'
 }
 

--- a/src/main/java/com/example/testsupport/framework/junit/retries/RetryableParameterizedTest.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/RetryableParameterizedTest.java
@@ -1,4 +1,4 @@
-package com.example.testsupport.annotations;
+package com.example.testsupport.framework.junit.retries;
 
 import com.example.testsupport.framework.device.DeviceProvider;
 import org.junit.jupiter.api.TestTemplate;

--- a/src/main/java/com/example/testsupport/framework/junit/retries/RetryableParameterizedTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/RetryableParameterizedTestExtension.java
@@ -1,6 +1,6 @@
-package com.example.testsupport.annotations;
+package com.example.testsupport.framework.junit.retries;
 
-import com.example.testsupport.annotations.RetryableParameterizedTest;
+import com.example.testsupport.framework.junit.retries.RetryableParameterizedTest;
 import io.github.artsok.internal.RepeatedIfException;
 import io.github.artsok.internal.ParameterizedRepeatedIfExceptionsTestNameFormatter;
 import io.github.artsok.internal.ParameterizedRepeatedMethodContext;

--- a/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTest.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTest.java
@@ -1,4 +1,4 @@
-package com.example.testsupport.annotations;
+package com.example.testsupport.framework.junit.retries;
 
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestTemplate;

--- a/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTestExtension.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  *
  */
-package com.example.testsupport.annotations;
+package com.example.testsupport.framework.junit.retries;
 
 
-import com.example.testsupport.annotations.RetryableTest;
+import com.example.testsupport.framework.junit.retries.RetryableTest;
 import io.github.artsok.internal.RepeatedIfException;
 import io.github.artsok.internal.RepeatedIfExceptionsDisplayNameFormatter;
 import io.github.artsok.internal.RepeatedIfExceptionsInvocationContext;

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -1,7 +1,7 @@
 package tests;
 
 import com.example.testsupport.framework.device.Device;
-import com.example.testsupport.annotations.RetryableParameterizedTest;
+import com.example.testsupport.framework.junit.retries.RetryableParameterizedTest;
 import com.example.testsupport.pages.MainPage;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;


### PR DESCRIPTION
## Summary
- move retryable annotations and extensions to main framework package for reuse
- update rerunner-jupiter dependency visibility to implementation
- fix test imports to new retry package

## Testing
- `gradle test -Dspring.profiles.active=spelet-demo --console=plain` *(fails: Playwright browser download socket closed)*

------
https://chatgpt.com/codex/tasks/task_e_68b46a0bde9c832fbe60355f9ce3b49b