### PR TITLE
docs: add comprehensive README and report gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,246 @@
-# Spelet Playwright Java
+# 🎯 Фреймворк Spelet Playwright
 
-## 🚀 Playwright tracing with Allure integration
+Spring Boot + Playwright фреймворк для надёжного UI‑тестирования с богатыми Allure‑отчётами.
 
-This project records [Playwright](https://playwright.dev/java/) traces for each test. When a test fails, the trace is saved to disk and automatically attached to the Allure report for interactive debugging.
+![Java](https://img.shields.io/badge/Java-21+-blue?logo=openjdk)
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.4-brightgreen?logo=springboot)
+![Playwright](https://img.shields.io/badge/Playwright-1.48-45ba52?logo=playwright)
+![Gradle](https://img.shields.io/badge/Gradle-8.14-blue?logo=gradle)
+![JUnit 5](https://img.shields.io/badge/JUnit%205-5.10-25A162?logo=junit5)
+![Allure](https://img.shields.io/badge/Allure-2.29-ff69b4?logo=allure)
 
-### Running tests
-```bash
-./gradlew clean test -Dspring.profiles.active=spelet
+---
+
+## Фреймворк в действии
+[Демонстрационная GIF-анимация будет добавлена позже]
+
+## Философия и ключевые особенности
+- **Конфигурация как код** — профили YAML управляют браузерами, устройствами и параллелизмом.
+- **Самовосстанавливающиеся тесты** — кастомные аннотации `@RetryableTest` и `@RetryableParameterizedTest`.
+- **Глубокая интеграция с Allure** — шаги, вложения и кастомные сьюты «из коробки».
+- **Удобство для разработчиков** — типизированный API‑клиент на паттерне Builder и автоматическое маппирование параметров.
+
+## Технологический стек
+| Категория | Технология | Назначение |
+| --- | --- | --- |
+| Язык | Java 21 | Основной язык |
+| Фреймворк | Spring Boot 3.5 | DI и конфигурация |
+| Автоматизация браузера | Playwright 1.48 | Взаимодействие с UI |
+| Сборка | Gradle 8.14 | Сборка и зависимости |
+| Тестирование | JUnit 5 | Запуск тестов |
+| Отчётность | Allure 2.29 | Богатые отчёты |
+| Облачный грид | BrowserStack | Кросс‑браузерные/устройствные прогоны |
+| HTTP | OpenFeign | Типизированные API‑клиенты |
+
+## Быстрый старт
+1. **Клонируйте репозиторий**
+   ```bash
+   git clone https://github.com/your-user/spelet-playwright-java.git
+   cd spelet-playwright-java
+   ```
+2. **Установите браузеры Playwright**
+   ```bash
+   gradle playwrightInstall
+   ```
+3. **Запустите тесты**
+   ```bash
+   gradle test -Dspring.profiles.active=spelet -Denv.browser.headless=true
+   ```
+4. **Посмотрите отчёт Allure**
+   ```bash
+   gradle allureServe
+   ```
+
+## Гайд по использованию
+### Запуск сценариев
+- **Локальный профиль**
+  ```bash
+  gradle test -Dspring.profiles.active=spelet -Denv.browser.headless=true
+  ```
+- **BrowserStack: Chrome на Windows**
+  ```bash
+  gradle bsWin10Chrome -Dspring.profiles.active=spelet-bs -Denv.browser.headless=true
+  ```
+- **Демо-окружение**
+  ```bash
+  gradle test -Dspring.profiles.active=spelet-demo -Denv.browser.headless=true
+  ```
+- **Фильтр устройств**
+  ```bash
+  gradle test -Dspring.profiles.active=spelet -Dtest.devices="Desktop FullHD,MacBook Pro"
+  ```
+- **Запуск отдельных тестов**
+  ```bash
+  gradle test -Dspring.profiles.active=spelet --tests "*MultilingualNavigation*"
+  ```
+
+### Примеры фич
+```java
+@RetryableTest(repeats = 3, suspend = 1000)
+void flakyLogic() {
+    // ...
+}
+```
+```java
+@RetryableParameterizedTest(name = "[Device: {0}, Lang: {1}]")
+void navigate(Device device, String lang) { /* ... */ }
+```
+```java
+@Suite("Navigation and casino flow")
+class MultilingualNavigationTest { /* ... */ }
+```
+```java
+GamblingBrandsParams params = GamblingBrandsParams.builder()
+        .platformNodeId("spelet.lv")
+        .platformLocale("lv")
+        .deviceType("desktop")
+        .build();
 ```
 
-### Analysing a failed test
-1. Generate and open the Allure report as usual.
-2. Locate a test marked as **FAILED** and download the `Playwright Trace` attachment.
-3. View the trace locally with:
-   ```bash
-   npx playwright show-trace path/to/trace.zip
-   ```
-   This opens a timeline that lets you step through actions, inspect DOM snapshots and review network/console logs.
+## Архитектура в деталях
+### YAML‑управляемый параллелизм и ретраи
+Gradle читает активный Spring‑профиль и на лету настраивает JUnit:
+```groovy
+tasks.withType(Test) {
+    useJUnitPlatform()
+    systemProperties = System.getProperties() as Map<String, ?>
+    jvmArgs '-Dfile.encoding=UTF-8', '--add-opens=java.base/java.lang=ALL-UNNAMED'
+    dependsOn(playwrightInstall)
 
-### Trace artifacts
-Trace files are stored in `build/traces` using the test name for easy identification. Traces are only saved for failed tests to keep the directory clean.
+    testLogging {
+        events "passed", "skipped", "failed"
+        exceptionFormat "full"
+        showStandardStreams = true
+    }
 
-The existing Allure integration remains the single source for failure analysis, now enriched with Playwright trace attachments.
-
-## 📊 How to read the enhanced Allure report
-
-Our Allure report now serves as a comprehensive diagnostic dashboard for every test run.
-
-### 1. Performance analysis (all tests)
-Open any test case. In the **Test Body** section you'll find a tree of nested steps. Each step displays its execution time, helping to spot slow areas in the application or test code.
-
-### 2. Failed test analysis (three levels)
-When a test fails, open it in Allure and inspect the following attachments:
-
-1. **Visual context** – check the `Screenshot` and `Current URL` attachments to see what the user saw at the moment of failure.
-2. **Frontend context** – review the `Browser Console Logs` attachment. Look for `[ERROR]` messages that often explain the root cause (JavaScript exceptions, network issues, etc.).
-3. **Deep analysis** – download the `Playwright Trace` (`.zip`) and open it locally with:
-   ```bash
-   npx playwright show-trace <trace-file>
-   ```
-   This provides an interactive timeline for step-by-step debugging.
-
-Only failed tests include console logs and trace attachments to keep reports lightweight.
-
-## 🌐 Configuration
-Environment settings are stored in profile-specific YAML files under `src/test/resources`.
-Spring Boot loads `application-<profile>.yml` based on the active profile.
-Each file can also control JUnit concurrency via the `env.parallelism` block.
-
-Example `application-spelet.yml` structure:
-```yaml
-env:
-  parallelism:
-    strategy: fixed
-    threads: 4
-  api:
-    baseUrl: https://spelet.lv
-  browser:
-    name: chromium
-    headless: false
-    language: lv
-    defaultLanguage: lv
+    doFirst {
+        def activeProfile = System.getProperty('spring.profiles.active')
+        if (!activeProfile) {
+            activeProfile = systemProperties['spring.profiles.active']
+        }
+        if (activeProfile == null || activeProfile.trim().isEmpty()) {
+            throw new GradleException("ERROR: Spring profile is not set. Please run tests with -Dspring.profiles.active=<profile>")
+        }
+    }
+}
 ```
 
-### Running with different profiles
-- Local run (auto-applies `local` mode profile):
-  ```bash
-  ./gradlew test -Dspring.profiles.active=spelet
-  ```
-- BrowserStack run (auto-applies `browserstack` mode profile):
-  ```bash
-  ./gradlew bsWin10Chrome -Dspring.profiles.active=spelet-demo
-  ```
-- Any other profile:
-  ```bash
-  ./gradlew test -Dspring.profiles.active=<profile>
-  ```
+### Матрица устройств и языков
+`TestMatrixService` формирует комбинации девайсов и локалей для параметризованных тестов:
+```java
+public Stream<List<Object>> getTestMatrix() {
+    List<Device> allDevices = config.getTestDevices().getPlatforms();
+    if (allDevices == null || allDevices.isEmpty()) {
+        throw new IllegalStateException("No test devices configured under env.test-devices.platforms");
+    }
+    List<String> languages = config.getBrowser().getLanguages();
+    if (languages == null || languages.isEmpty()) {
+        languages = List.of("lv", "ru", "en");
+    }
+    final List<String> finalLanguages = languages;
 
-The `spring.profiles.active` property selects the configuration profile and is mandatory.
-Gradle tasks add the appropriate mode profile (`local` or `browserstack`) automatically.
-To create a new environment, add `application-myenv.yml` and run tests with
-`-Dspring.profiles.active=myenv`.
+    String filter = System.getProperty("test.devices");
+    List<Device> devices;
+    if (filter == null || filter.isBlank()) {
+        devices = allDevices;
+    } else {
+        Set<String> requested = Arrays.stream(filter.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toSet());
+        Map<String, Device> deviceMap = allDevices.stream()
+                .collect(Collectors.toMap(Device::getName, Function.identity()));
+        List<String> missing = requested.stream()
+                .filter(name -> !deviceMap.containsKey(name))
+                .toList();
+        if (!missing.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Device(s) not found in configuration: " + String.join(", ", missing));
+        }
+        devices = requested.stream().map(deviceMap::get).toList();
+    }
 
-## 🧩 Custom suite names in Allure
+    return devices.stream()
+            .flatMap(device -> finalLanguages.stream()
+                    .map(lang -> List.of(device, lang)));
+}
+```
 
-Annotate test classes or methods with `@Suite("Human readable name")` to set a
-clear, business-oriented suite name in the Allure report. When both class and
-method are annotated, the method-level value takes precedence. Tests without the
-annotation continue to use the default class name.
+### Генерический интерцептор параметров API
+Кастомный интерцептор Feign сопоставляет аннотированные поля с query‑параметрами и заголовками:
+```java
+public class GenericParamsInterceptor implements RequestInterceptor {
+
+    @Override
+    public void apply(RequestTemplate template) {
+        if (!template.queries().containsKey("params")) {
+            return;
+        }
+
+        Collection<?> paramsCollection = template.queries().get("params");
+        if (paramsCollection == null || paramsCollection.isEmpty()) {
+            clearParamsQuery(template);
+            return;
+        }
+
+        Object params = paramsCollection.iterator().next();
+        clearParamsQuery(template);
+
+        for (Field field : params.getClass().getDeclaredFields()) {
+            field.setAccessible(true);
+            try {
+                Object value = field.get(params);
+                if (value == null) {
+                    continue;
+                }
+                RequestQueryParam queryAnn = field.getAnnotation(RequestQueryParam.class);
+                if (queryAnn != null) {
+                    template.query(queryAnn.value(), value.toString());
+                }
+                RequestHeaderParam headerAnn = field.getAnnotation(RequestHeaderParam.class);
+                if (headerAnn != null) {
+                    template.header(headerAnn.value(), value.toString());
+                }
+            } catch (IllegalAccessException ignored) {
+                // поле недоступно
+            }
+        }
+    }
+
+    private void clearParamsQuery(RequestTemplate template) {
+        Map<String, Collection<String>> queries = new LinkedHashMap<>(template.queries());
+        queries.remove("params");
+        template.queries(queries);
+    }
+}
+```
+
+### Кастомные сьюты Allure
+`CustomSuiteExtension` переписывает label `suite` на основе аннотации `@Suite`:
+```java
+public class CustomSuiteExtension implements BeforeTestExecutionCallback {
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context) {
+        Suite suite = resolveSuite(context);
+        if (suite == null) {
+            return;
+        }
+        Allure.getLifecycle().updateTestCase(tc -> tc.getLabels().removeIf(l -> "suite".equals(l.getName())));
+        Allure.getLifecycle().updateTestCase(tc -> tc.getLabels().add(new Label().setName("suite").setValue(suite.value())));
+    }
+
+    private Suite resolveSuite(ExtensionContext context) {
+        Optional<Suite> methodSuite = context.getTestMethod().map(m -> m.getAnnotation(Suite.class));
+        if (methodSuite.isPresent()) {
+            return methodSuite.get();
+        }
+        return context.getTestClass().map(c -> c.getAnnotation(Suite.class)).orElse(null);
+    }
+}
+```
+
+## Галерея отчётов
+| Дашборд с кастомными сьютами | Детализация шагов | Карточка упавшего теста | Пример flaky-теста |
+| --- | --- | --- | --- |
+| ![Dashboard screenshot placeholder](docs/report_dashboard.png) | ![Steps screenshot placeholder](docs/report_steps.png) | ![Failed test screenshot placeholder](docs/report_failed.png) | ![Flaky test screenshot placeholder](docs/report_flaky.png) |

--- a/docs/.gitkeep
+++ b/docs/.gitkeep
@@ -1,0 +1,1 @@
+placeholder for future screenshots


### PR DESCRIPTION
## Summary
- локализован README на русский и уточнены команды Gradle
- выделены ключевые фичи и оставлены placeholders под скриншоты Allure

## Testing
- `gradle playwrightInstall --no-daemon` *(fails: ERR_SOCKET_CLOSED)*
- `gradle test -Dspring.profiles.active=spelet -Denv.browser.headless=true --no-daemon` *(fails: :playwrightInstall)*

------
https://chatgpt.com/codex/tasks/task_e_68b46fbc9318832f89857436cac3fbe8