### PR TITLE
Register GenericParamsInterceptor globally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     compileOnly 'io.github.openfeign:feign-okhttp'
     testImplementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     testImplementation 'io.github.openfeign:feign-okhttp'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/testsupport/framework/api/config/FeignParamsConfig.java
+++ b/src/main/java/com/example/testsupport/framework/api/config/FeignParamsConfig.java
@@ -1,0 +1,18 @@
+package com.example.testsupport.framework.api.config;
+
+import feign.RequestInterceptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class that registers {@link com.example.testsupport.framework.api.client.GenericParamsInterceptor} as a Feign {@link RequestInterceptor}.
+ */
+@Configuration
+public class FeignParamsConfig {
+
+    @Bean
+    public RequestInterceptor genericParamsInterceptor() {
+        return new com.example.testsupport.framework.api.client.GenericParamsInterceptor();
+    }
+}
+

--- a/src/test/java/com/example/testsupport/config/TestConfig.java
+++ b/src/test/java/com/example/testsupport/config/TestConfig.java
@@ -4,10 +4,19 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import com.example.testsupport.framework.api.config.AllureFeignLoggerConfig;
+import com.example.testsupport.framework.api.config.FeignParamsConfig;
+
 /**
  * Primary test configuration that registers base beans.
  */
 @Configuration
-@EnableFeignClients(basePackages = "com.example.testsupport.framework.api.client")
+@EnableFeignClients(
+        basePackages = "com.example.testsupport.framework.api.client",
+        defaultConfiguration = {
+                FeignParamsConfig.class,
+                AllureFeignLoggerConfig.class
+        }
+)
 @Import(PageConfig.class)
 public class TestConfig { }

--- a/src/test/java/com/example/testsupport/framework/api/client/FrontApiClient.java
+++ b/src/test/java/com/example/testsupport/framework/api/client/FrontApiClient.java
@@ -6,7 +6,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(name = "frontApiClient", url = "${env.api.base-url}", configuration = GenericParamsInterceptor.class)
+@FeignClient(name = "frontApiClient", url = "${env.api.base-url}")
 public interface FrontApiClient {
 
     @GetMapping("/_front_api/api/v1/gambling/brands")

--- a/src/test/java/com/example/testsupport/framework/api/client/GenericParamsInterceptorTest.java
+++ b/src/test/java/com/example/testsupport/framework/api/client/GenericParamsInterceptorTest.java
@@ -1,0 +1,60 @@
+package com.example.testsupport.framework.api.client;
+
+import com.example.testsupport.TestApplication;
+import com.example.testsupport.framework.api.client.params.GamblingBrandsParams;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@SpringBootTest(classes = TestApplication.class)
+class GenericParamsInterceptorTest {
+
+    private static MockWebServer mockWebServer;
+
+    @Autowired
+    private FrontApiClient frontApiClient;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("env.api.base-url", () -> mockWebServer.url("/").toString());
+    }
+
+    @Test
+    void paramsQueryIsRemoved() throws Exception {
+        mockWebServer.enqueue(new MockResponse().setBody("{\"brands\":[]}")
+                .addHeader("Content-Type", "application/json"));
+
+        GamblingBrandsParams params = GamblingBrandsParams.builder()
+                .platformLocale("lv")
+                .categoryAlias("new")
+                .build();
+
+        frontApiClient.getGamblingBrands(params);
+
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertFalse(request.getRequestUrl().queryParameterNames().contains("params"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a Feign configuration that registers GenericParamsInterceptor as a RequestInterceptor
- enable Feign clients with global defaults and clean up FrontApiClient
- cover interceptor with a mock server test

## Testing
- `gradle test -Dspring.profiles.active=spelet-demo --tests "com.example.testsupport.framework.api.client.GenericParamsInterceptorTest" -x playwrightInstall`

------
https://chatgpt.com/codex/tasks/task_e_68b5d591c834832fabba9cadb8a11835