### PR TITLE
Fix retry mechanism and simplify AllureHelper

### DIFF
--- a/src/main/java/com/example/testsupport/framework/junit/retries/RetryableParameterizedTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/RetryableParameterizedTestExtension.java
@@ -145,7 +145,7 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
     private boolean exceptionAppeared(ExtensionContext extensionContext) {
         if (extensionContext.getExecutionException().isPresent()) {
             Throwable exception = extensionContext.getExecutionException().get();
-            List<Class<? extends Throwable>> repeatableExceptions = getStore(extensionContext).get(REPEATABLE_EXCEPTIONS_KEY, List.class);
+            List<Class<? extends Throwable>> repeatableExceptions = getConfigStore(extensionContext).get(REPEATABLE_EXCEPTIONS_KEY, List.class);
             return isExceptionRetryable(exception, repeatableExceptions);
         }
         return false;
@@ -178,7 +178,7 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
      */
     private boolean isMinSuccessTargetStillReachable(ExtensionContext context, final long minSuccessCount) {
         List<Boolean> history = getHistory(context);
-        int totalRepeats = getStore(context).get(TOTAL_REPEATS_KEY, Integer.class);
+        int totalRepeats = getConfigStore(context).get(TOTAL_REPEATS_KEY, Integer.class);
         return history.stream().filter(bool -> bool).count() <= totalRepeats - minSuccessCount;
     }
 

--- a/src/main/java/com/example/testsupport/framework/junit/retries/RetryableParameterizedTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/RetryableParameterizedTestExtension.java
@@ -137,8 +137,8 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
 
     private boolean exceptionAppeared(ExtensionContext extensionContext) {
         if (extensionContext.getExecutionException().isPresent()) {
-            Class<? extends Throwable> exception = extensionContext.getExecutionException().get().getClass();
-            return repeatableExceptions.stream().anyMatch(ex -> ex.isAssignableFrom(exception));
+            Throwable exception = extensionContext.getExecutionException().get();
+            return isExceptionRetryable(exception, repeatableExceptions);
         }
         return false;
     }
@@ -146,6 +146,8 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
     @Override
     public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
         if (appearedExceptionDoesNotAllowRepetitions(throwable)) {
+            System.out.printf("Test failed with exception chain [%s] which is not configured for retry. Failing fast.%n",
+                    buildExceptionChain(throwable));
             throw throwable;
         }
         repeatableExceptionAppeared = true;
@@ -168,7 +170,29 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
     }
 
     private boolean appearedExceptionDoesNotAllowRepetitions(Throwable appearedException) {
-        return repeatableExceptions.stream().noneMatch(ex -> ex.isAssignableFrom(appearedException.getClass()));
+        return !isExceptionRetryable(appearedException, repeatableExceptions);
+    }
+
+    private boolean isExceptionRetryable(Throwable throwable, List<Class<? extends Throwable>> retryableExceptions) {
+        if (throwable == null) {
+            return false;
+        }
+        for (Class<? extends Throwable> ex : retryableExceptions) {
+            if (ex.isAssignableFrom(throwable.getClass())) {
+                return true;
+            }
+        }
+        return isExceptionRetryable(throwable.getCause(), retryableExceptions);
+    }
+
+    private String buildExceptionChain(Throwable throwable) {
+        List<String> chain = new ArrayList<>();
+        Throwable current = throwable;
+        while (current != null) {
+            chain.add(current.getClass().getName());
+            current = current.getCause();
+        }
+        return String.join(" -> ", chain);
     }
 
     private ParameterizedRepeatedIfExceptionsTestNameFormatter createNameFormatter(Method templateMethod, String displayName) {

--- a/src/main/java/com/example/testsupport/framework/junit/retries/RetryableParameterizedTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/RetryableParameterizedTestExtension.java
@@ -151,13 +151,10 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
         repeatableExceptionAppeared = true;
 
         long currentSuccessCount = historyExceptionAppear.stream().filter(exceptionAppeared -> !exceptionAppeared).count();
-        if (currentSuccessCount < minSuccess) {
-            if (isMinSuccessTargetStillReachable(minSuccess)) {
-                throw new TestAbortedException("Do not fail completely, but repeat the test", throwable);
-            } else {
-                throw throwable;
-            }
+        if (currentSuccessCount < minSuccess && isMinSuccessTargetStillReachable(minSuccess)) {
+            throw new TestAbortedException("Do not fail completely, but repeat the test", throwable);
         }
+        throw throwable;
     }
 
     /**

--- a/src/main/java/com/example/testsupport/framework/junit/retries/RetryableParameterizedTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/RetryableParameterizedTestExtension.java
@@ -33,13 +33,13 @@ import static org.junit.platform.commons.util.AnnotationUtils.*;
 public class RetryableParameterizedTestExtension implements TestTemplateInvocationContextProvider,
         BeforeTestExecutionCallback, AfterTestExecutionCallback, TestExecutionExceptionHandler {
 
-    private int totalRepeats = 0;
-    private int minSuccess = 1;
-    private List<Class<? extends Throwable>> repeatableExceptions;
-    private boolean repeatableExceptionAppeared = false;
-    private final List<Boolean> historyExceptionAppear = Collections.synchronizedList(new ArrayList<>());
     private static final String METHOD_CONTEXT_KEY = "context";
-    private long suspend = 0L;
+    private static final String TOTAL_REPEATS_KEY = "totalRepeats";
+    private static final String MIN_SUCCESS_KEY = "minSuccess";
+    private static final String SUSPEND_KEY = "suspend";
+    private static final String REPEATABLE_EXCEPTIONS_KEY = "repeatableExceptions";
+    private static final String REPEATABLE_EXCEPTION_APPEARED_KEY = "repeatableExceptionAppeared";
+    private static final String HISTORY_KEY = "history";
 
     @Override
     public boolean supportsTestTemplate(ExtensionContext extensionContext) {
@@ -61,7 +61,7 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
                                 + "and before any arguments resolved by another ParameterResolver.",
                         testMethod.toGenericString()));
 
-        getStore(extensionContext).put(METHOD_CONTEXT_KEY, methodContext);
+        getConfigStore(extensionContext).put(METHOD_CONTEXT_KEY, methodContext);
         return true;
     }
 
@@ -69,7 +69,7 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
     public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext extensionContext) {
         Method templateMethod = extensionContext.getRequiredTestMethod();
         String displayName = extensionContext.getDisplayName();
-        ParameterizedRepeatedMethodContext methodContext = getStore(extensionContext)//
+        ParameterizedRepeatedMethodContext methodContext = getConfigStore(extensionContext)//
                 .get(METHOD_CONTEXT_KEY, ParameterizedRepeatedMethodContext.class);
         ParameterizedRepeatedIfExceptionsTestNameFormatter formatter = createNameFormatter(templateMethod, displayName);
 
@@ -78,9 +78,9 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
                 .orElseThrow(() -> new RepeatedIfException("The extension should not be executed "
                         + "unless the test method is annotated with @RetryableParameterizedTest."));
 
-        totalRepeats = annotationParams.repeats();
-        minSuccess = annotationParams.minSuccess();
-        suspend = annotationParams.suspend();
+        int totalRepeats = annotationParams.repeats();
+        int minSuccess = annotationParams.minSuccess();
+        long suspend = annotationParams.suspend();
 
         String strTotalRepeats = System.getProperty("totalRepeats");
         if (strTotalRepeats != null) {
@@ -101,6 +101,11 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
         Preconditions.condition(totalRepeats > 0, "Total repeats must be higher than 0");
         Preconditions.condition(minSuccess >= 1, "Total minimum success must be higher or equals than 1");
 
+        ExtensionContext.Store store = getConfigStore(extensionContext);
+        store.put(TOTAL_REPEATS_KEY, totalRepeats);
+        store.put(MIN_SUCCESS_KEY, minSuccess);
+        store.put(SUSPEND_KEY, suspend);
+
 
         List<Object[]> collect = findRepeatableAnnotations(templateMethod, ArgumentsSource.class)
                 .stream()
@@ -113,31 +118,34 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
                 .collect(Collectors.toList());
 
         Spliterator<TestTemplateInvocationContext> spliterator =
-                spliteratorUnknownSize(new TestTemplateIteratorParams(collect, formatter, methodContext), Spliterator.NONNULL);
+                spliteratorUnknownSize(new TestTemplateIteratorParams(collect, formatter, methodContext, extensionContext), Spliterator.NONNULL);
         return stream(spliterator, false);
 
     }
 
     @Override
     public void beforeTestExecution(ExtensionContext context) {
-        repeatableExceptions = Stream.of(context.getTestMethod()
+        List<Class<? extends Throwable>> repeatableExceptions = Stream.of(context.getTestMethod()
                 .flatMap(testMethods -> findAnnotation(testMethods, RetryableParameterizedTest.class))
                 .orElseThrow(() -> new IllegalStateException("The extension should not be executed "))
                 .exceptions()
         ).collect(Collectors.toList());
         repeatableExceptions.add(TestAbortedException.class);
+        getConfigStore(context).put(REPEATABLE_EXCEPTIONS_KEY, repeatableExceptions);
     }
 
     //Записываем в historyExceptionAppear по конкретным аргументам!
     @Override
     public void afterTestExecution(ExtensionContext context) {
         boolean exceptionAppeared = exceptionAppeared(context);
-        historyExceptionAppear.add(exceptionAppeared);
+        List<Boolean> history = getHistory(context);
+        history.add(exceptionAppeared);
     }
 
     private boolean exceptionAppeared(ExtensionContext extensionContext) {
         if (extensionContext.getExecutionException().isPresent()) {
             Throwable exception = extensionContext.getExecutionException().get();
+            List<Class<? extends Throwable>> repeatableExceptions = getStore(extensionContext).get(REPEATABLE_EXCEPTIONS_KEY, List.class);
             return isExceptionRetryable(exception, repeatableExceptions);
         }
         return false;
@@ -145,15 +153,18 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
 
     @Override
     public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
-        if (appearedExceptionDoesNotAllowRepetitions(throwable)) {
+        List<Class<? extends Throwable>> repeatableExceptions = getConfigStore(context).get(REPEATABLE_EXCEPTIONS_KEY, List.class);
+        if (!isExceptionRetryable(throwable, repeatableExceptions)) {
             System.out.printf("Test failed with exception chain [%s] which is not configured for retry. Failing fast.%n",
                     buildExceptionChain(throwable));
             throw throwable;
         }
-        repeatableExceptionAppeared = true;
+        setRepeatableExceptionAppeared(context, true);
 
-        long currentSuccessCount = historyExceptionAppear.stream().filter(exceptionAppeared -> !exceptionAppeared).count();
-        if (currentSuccessCount < minSuccess && isMinSuccessTargetStillReachable(minSuccess)) {
+        List<Boolean> history = getHistory(context);
+        int minSuccess = getConfigStore(context).get(MIN_SUCCESS_KEY, Integer.class);
+        long currentSuccessCount = history.stream().filter(exceptionAppeared -> !exceptionAppeared).count();
+        if (currentSuccessCount < minSuccess && isMinSuccessTargetStillReachable(context, minSuccess)) {
             throw new TestAbortedException("Do not fail completely, but repeat the test", throwable);
         }
         throw throwable;
@@ -165,12 +176,10 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
      * @param minSuccessCount - minimum success count
      * @return true/false
      */
-    private boolean isMinSuccessTargetStillReachable(final long minSuccessCount) {
-        return historyExceptionAppear.stream().filter(bool -> bool).count() <= totalRepeats - minSuccessCount;
-    }
-
-    private boolean appearedExceptionDoesNotAllowRepetitions(Throwable appearedException) {
-        return !isExceptionRetryable(appearedException, repeatableExceptions);
+    private boolean isMinSuccessTargetStillReachable(ExtensionContext context, final long minSuccessCount) {
+        List<Boolean> history = getHistory(context);
+        int totalRepeats = getStore(context).get(TOTAL_REPEATS_KEY, Integer.class);
+        return history.stream().filter(bool -> bool).count() <= totalRepeats - minSuccessCount;
     }
 
     private boolean isExceptionRetryable(Throwable throwable, List<Class<? extends Throwable>> retryableExceptions) {
@@ -239,7 +248,26 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
     }
 
     private ExtensionContext.Store getStore(ExtensionContext context) {
-        return context.getStore(ExtensionContext.Namespace.create(RetryableParameterizedTestExtension.class, context.getRequiredTestMethod()));
+        return context.getStore(ExtensionContext.Namespace.create(getClass(), context.getUniqueId()));
+    }
+
+    private ExtensionContext.Store getConfigStore(ExtensionContext context) {
+        return context.getStore(ExtensionContext.Namespace.create(getClass(), context.getRequiredTestMethod()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Boolean> getHistory(ExtensionContext context) {
+        ExtensionContext.Store store = getStore(context);
+        return (List<Boolean>) store.getOrComputeIfAbsent(HISTORY_KEY, key -> Collections.synchronizedList(new ArrayList<>()), List.class);
+    }
+
+    private void setRepeatableExceptionAppeared(ExtensionContext context, boolean appeared) {
+        getStore(context).put(REPEATABLE_EXCEPTION_APPEARED_KEY, appeared);
+    }
+
+    private boolean getRepeatableExceptionAppeared(ExtensionContext context) {
+        Boolean value = getStore(context).get(REPEATABLE_EXCEPTION_APPEARED_KEY, Boolean.class);
+        return value != null && value;
     }
 
     /**
@@ -253,19 +281,23 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
         private final AtomicLong invocationCount;
         private final AtomicLong paramsCount;
         private int currentIndex = 0;
+        private final ExtensionContext extensionContext;
 
-        TestTemplateIteratorParams(List<Object[]> arguments, final ParameterizedRepeatedIfExceptionsTestNameFormatter formatter, final ParameterizedRepeatedMethodContext methodContext) {
+        TestTemplateIteratorParams(List<Object[]> arguments, final ParameterizedRepeatedIfExceptionsTestNameFormatter formatter, final ParameterizedRepeatedMethodContext methodContext, ExtensionContext extensionContext) {
             this.params = arguments;
             this.formatter = formatter;
             this.methodContext = methodContext;
             this.invocationCount = new AtomicLong(params.size() - 1);
             this.paramsCount = new AtomicLong(0);
+            this.extensionContext = extensionContext;
         }
 
         @Override
         public boolean hasNext() {
-            if (!historyExceptionAppear.isEmpty()
-                    && historyExceptionAppear.get(historyExceptionAppear.size() - 1)
+        int totalRepeats = getConfigStore(extensionContext).get(TOTAL_REPEATS_KEY, Integer.class);
+            List<Boolean> history = getHistory(extensionContext);
+            if (!history.isEmpty()
+                    && history.get(history.size() - 1)
                     && currentIndex < totalRepeats) {
                 return true;
             }
@@ -285,17 +317,21 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
 
             if (hasNext()) {
                 int currentParam = paramsCount.intValue();
-                int errorTestRepetitionsCountForOneArgument = toIntExact(historyExceptionAppear.stream().filter(b -> b).count());
-                int successfulTestRepetitionsCountForOneArgument = toIntExact(historyExceptionAppear
+                List<Boolean> history = getHistory(extensionContext);
+                int totalRepeats = getConfigStore(extensionContext).get(TOTAL_REPEATS_KEY, Integer.class);
+                int minSuccess = getConfigStore(extensionContext).get(MIN_SUCCESS_KEY, Integer.class);
+                int errorTestRepetitionsCountForOneArgument = toIntExact(history.stream().filter(b -> b).count());
+                int successfulTestRepetitionsCountForOneArgument = toIntExact(history
                         .stream()
-                        .skip(historyExceptionAppear.size() - minSuccess <= 0 ? 0 : historyExceptionAppear.size() - minSuccess)
+                        .skip(history.size() - minSuccess <= 0 ? 0 : history.size() - minSuccess)
                         .filter(b -> !b)
                         .count());
 
                 if (errorTestRepetitionsCountForOneArgument >= 1 && currentIndex < totalRepeats && successfulTestRepetitionsCountForOneArgument != minSuccess) {
 
                     //If exception appeared would wait suspend time
-                    if (historyExceptionAppear.stream().anyMatch(ex -> ex) && suspend != 0L) {
+                    long suspend = getConfigStore(extensionContext).get(SUSPEND_KEY, Long.class);
+                    if (history.stream().anyMatch(ex -> ex) && suspend != 0L) {
                         try {
                             Thread.sleep(suspend);
                         } catch (InterruptedException e) {
@@ -304,14 +340,14 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
                     }
 
                     currentIndex++;
-                    repeatableExceptionAppeared = false;
+                    setRepeatableExceptionAppeared(extensionContext, false);
                     return new ParameterizedTestInvocationContext(currentIndex, totalRepeats, formatter, methodContext, params.get(currentParam - 1));
                 }
 
-                if (currentIndex == totalRepeats || !repeatableExceptionAppeared) {
+                if (currentIndex == totalRepeats || !getRepeatableExceptionAppeared(extensionContext)) {
                     paramsCount.incrementAndGet();
-                    repeatableExceptionAppeared = false;
-                    historyExceptionAppear.clear();
+                    setRepeatableExceptionAppeared(extensionContext, false);
+                    history.clear();
                 }
 
                 currentIndex = 0;

--- a/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTestExtension.java
@@ -145,10 +145,11 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
     }
 
     private boolean exceptionAppeared(ExtensionContext extensionContext) {
-        Class<? extends Throwable> exception = extensionContext.getExecutionException()
-                .orElse(new RepeatedIfException("There is no exception in context")).getClass();
-        return repeatableExceptions.stream()
-                .anyMatch(ex -> ex.isAssignableFrom(exception) && !RepeatedIfException.class.isAssignableFrom(exception));
+        if (extensionContext.getExecutionException().isEmpty()) {
+            return false;
+        }
+        Throwable exception = extensionContext.getExecutionException().get();
+        return isExceptionRetryable(exception, repeatableExceptions);
     }
 
     /**
@@ -170,6 +171,8 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
     @Override
     public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
         if (appearedExceptionDoesNotAllowRepetitions(throwable)) {
+            System.out.printf("Test failed with exception chain [%s] which is not configured for retry. Failing fast.%n",
+                    buildExceptionChain(throwable));
             throw throwable;
         }
         repeatableExceptionAppeared = true;
@@ -188,7 +191,29 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
      * @return true/false
      */
     private boolean appearedExceptionDoesNotAllowRepetitions(final Throwable appearedException) {
-        return repeatableExceptions.stream().noneMatch(ex -> ex.isAssignableFrom(appearedException.getClass()));
+        return !isExceptionRetryable(appearedException, repeatableExceptions);
+    }
+
+    private boolean isExceptionRetryable(Throwable throwable, List<Class<? extends Throwable>> retryableExceptions) {
+        if (throwable == null) {
+            return false;
+        }
+        for (Class<? extends Throwable> ex : retryableExceptions) {
+            if (ex.isAssignableFrom(throwable.getClass())) {
+                return true;
+            }
+        }
+        return isExceptionRetryable(throwable.getCause(), retryableExceptions);
+    }
+
+    private String buildExceptionChain(Throwable throwable) {
+        List<String> chain = new ArrayList<>();
+        Throwable current = throwable;
+        while (current != null) {
+            chain.add(current.getClass().getName());
+            current = current.getCause();
+        }
+        return String.join(" -> ", chain);
     }
 
     /**

--- a/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTestExtension.java
@@ -175,13 +175,10 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
         repeatableExceptionAppeared = true;
 
         long currentSuccessCount = historyExceptionAppear.stream().filter(exceptionAppeared -> !exceptionAppeared).count();
-        if (currentSuccessCount < minSuccess) {
-            if (isMinSuccessTargetStillReachable(minSuccess)) {
-                throw new TestAbortedException("Do not fail completely, but repeat the test", throwable);
-            } else {
-                throw throwable;
-            }
+        if (currentSuccessCount < minSuccess && isMinSuccessTargetStillReachable(minSuccess)) {
+            throw new TestAbortedException("Do not fail completely, but repeat the test", throwable);
         }
+        throw throwable;
     }
 
     /**

--- a/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTestExtension.java
@@ -223,12 +223,14 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
     }
 
     private ExtensionContext.Store getStore(ExtensionContext context) {
-        return context.getStore(ExtensionContext.Namespace.create(getClass(), context.getUniqueId()));
+        return context.getStore(ExtensionContext.Namespace.create(getClass(), context.getRequiredTestMethod()));
     }
 
     @SuppressWarnings("unchecked")
     private List<Boolean> getHistory(ExtensionContext context) {
-        return (List<Boolean>) getStore(context).get(HISTORY_KEY, List.class);
+        ExtensionContext.Store store = getStore(context);
+        return (List<Boolean>) store.getOrComputeIfAbsent(HISTORY_KEY,
+                key -> Collections.synchronizedList(new ArrayList<>()), List.class);
     }
 
     private void setRepeatableExceptionAppeared(ExtensionContext context, boolean appeared) {

--- a/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTestExtension.java
@@ -47,15 +47,15 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
         AfterTestExecutionCallback, TestExecutionExceptionHandler {
 
 
-    private int repeats = 0;
-    private int minSuccess = 1;
-    private int totalTestRuns = 0;
-    private List<Class<? extends Throwable>> repeatableExceptions;
-    private boolean repeatableExceptionAppeared = false;
-    private RepeatedIfExceptionsDisplayNameFormatter formatter;
-    private List<Boolean> historyExceptionAppear;
-    private long suspend = 0L;
     private static final int CURRENT_RUN = 1;
+    private static final String REPEATS_KEY = "repeats";
+    private static final String MIN_SUCCESS_KEY = "minSuccess";
+    private static final String TOTAL_RUNS_KEY = "totalRuns";
+    private static final String REPEATABLE_EXCEPTIONS_KEY = "repeatableExceptions";
+    private static final String REPEATABLE_EXCEPTION_APPEARED_KEY = "repeatableExceptionAppeared";
+    private static final String HISTORY_KEY = "history";
+    private static final String SUSPEND_KEY = "suspend";
+    private RepeatedIfExceptionsDisplayNameFormatter formatter;
 
 
     /**
@@ -87,20 +87,26 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
 
 
         int totalRepeats = annotationParams.repeats();
-        minSuccess = annotationParams.minSuccess();
+        int minSuccess = annotationParams.minSuccess();
         Preconditions.condition(totalRepeats > 0, "Total repeats must be higher than 0");
         Preconditions.condition(minSuccess >= 1, "Total minimum success must be higher or equals than 1");
 
-        totalTestRuns = totalRepeats + CURRENT_RUN;
-        suspend = annotationParams.suspend();
-        historyExceptionAppear = Collections.synchronizedList(new ArrayList<>());
+        int totalTestRuns = totalRepeats + CURRENT_RUN;
+        long suspend = annotationParams.suspend();
+
+        ExtensionContext.Store store = getStore(extensionContext);
+        store.put(REPEATS_KEY, totalRepeats);
+        store.put(MIN_SUCCESS_KEY, minSuccess);
+        store.put(TOTAL_RUNS_KEY, totalTestRuns);
+        store.put(SUSPEND_KEY, suspend);
+        store.put(HISTORY_KEY, Collections.synchronizedList(new ArrayList<>()));
 
         String displayName = extensionContext.getDisplayName();
         formatter = displayNameFormatter(annotationParams, displayName);
 
         //Convert logic of repeated handler to spliterator
         Spliterator<TestTemplateInvocationContext> spliterator =
-                spliteratorUnknownSize(new TestTemplateIterator(), Spliterator.NONNULL);
+                spliteratorUnknownSize(new TestTemplateIterator(extensionContext), Spliterator.NONNULL);
         return stream(spliterator, false);
     }
 
@@ -108,29 +114,35 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
     public void beforeTestExecution(ExtensionContext context) {
             
         //get TotalTestRuns and minSuccess from system properties
+        ExtensionContext.Store store = getStore(context);
+        Integer totalRuns = store.get(TOTAL_RUNS_KEY, Integer.class);
+        Integer minSuccess = store.get(MIN_SUCCESS_KEY, Integer.class);
         String strTotalRepeats = System.getProperty("totalRepeats");
         if(strTotalRepeats != null) {
             try {
-                totalTestRuns = Integer.parseInt(strTotalRepeats);
+                totalRuns = Integer.parseInt(strTotalRepeats);
             }catch(Exception e){
             }
         }
 
-        
         String strMinSuccess = System.getProperty("minSuccess");
         if(strMinSuccess != null) {
             try {
-            	minSuccess = Integer.parseInt(strMinSuccess);
+                minSuccess = Integer.parseInt(strMinSuccess);
             }catch(Exception e){
             }
         }
-            
-        repeatableExceptions = Stream.of(context.getTestMethod()
+
+        store.put(TOTAL_RUNS_KEY, totalRuns);
+        store.put(MIN_SUCCESS_KEY, minSuccess);
+
+        List<Class<? extends Throwable>> repeatableExceptions = Stream.of(context.getTestMethod()
                 .flatMap(testMethods -> findAnnotation(testMethods, RetryableTest.class))
                 .orElseThrow(() -> new IllegalStateException("The extension should not be executed "))
                 .exceptions()
         ).collect(Collectors.toList());
         repeatableExceptions.add(TestAbortedException.class);
+        store.put(REPEATABLE_EXCEPTIONS_KEY, repeatableExceptions);
     }
 
     /**
@@ -141,7 +153,7 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
     @Override
     public void afterTestExecution(ExtensionContext extensionContext) {
         boolean exceptionAppeared = exceptionAppeared(extensionContext);
-        historyExceptionAppear.add(exceptionAppeared);
+        getHistory(extensionContext).add(exceptionAppeared);
     }
 
     private boolean exceptionAppeared(ExtensionContext extensionContext) {
@@ -149,6 +161,7 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
             return false;
         }
         Throwable exception = extensionContext.getExecutionException().get();
+        List<Class<? extends Throwable>> repeatableExceptions = getStore(extensionContext).get(REPEATABLE_EXCEPTIONS_KEY, List.class);
         return isExceptionRetryable(exception, repeatableExceptions);
     }
 
@@ -170,28 +183,21 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
 
     @Override
     public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
-        if (appearedExceptionDoesNotAllowRepetitions(throwable)) {
+        List<Class<? extends Throwable>> repeatableExceptions = getStore(context).get(REPEATABLE_EXCEPTIONS_KEY, List.class);
+        if (!isExceptionRetryable(throwable, repeatableExceptions)) {
             System.out.printf("Test failed with exception chain [%s] which is not configured for retry. Failing fast.%n",
                     buildExceptionChain(throwable));
             throw throwable;
         }
-        repeatableExceptionAppeared = true;
+        setRepeatableExceptionAppeared(context, true);
 
-        long currentSuccessCount = historyExceptionAppear.stream().filter(exceptionAppeared -> !exceptionAppeared).count();
-        if (currentSuccessCount < minSuccess && isMinSuccessTargetStillReachable(minSuccess)) {
+        List<Boolean> history = getHistory(context);
+        int minSuccess = getStore(context).get(MIN_SUCCESS_KEY, Integer.class);
+        long currentSuccessCount = history.stream().filter(exceptionAppeared -> !exceptionAppeared).count();
+        if (currentSuccessCount < minSuccess && isMinSuccessTargetStillReachable(context, minSuccess)) {
             throw new TestAbortedException("Do not fail completely, but repeat the test", throwable);
         }
         throw throwable;
-    }
-
-    /**
-     * If exception allowed, will return false
-     *
-     * @param appearedException - {@link Throwable}
-     * @return true/false
-     */
-    private boolean appearedExceptionDoesNotAllowRepetitions(final Throwable appearedException) {
-        return !isExceptionRetryable(appearedException, repeatableExceptions);
     }
 
     private boolean isExceptionRetryable(Throwable throwable, List<Class<? extends Throwable>> retryableExceptions) {
@@ -216,14 +222,34 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
         return String.join(" -> ", chain);
     }
 
+    private ExtensionContext.Store getStore(ExtensionContext context) {
+        return context.getStore(ExtensionContext.Namespace.create(getClass(), context.getUniqueId()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Boolean> getHistory(ExtensionContext context) {
+        return (List<Boolean>) getStore(context).get(HISTORY_KEY, List.class);
+    }
+
+    private void setRepeatableExceptionAppeared(ExtensionContext context, boolean appeared) {
+        getStore(context).put(REPEATABLE_EXCEPTION_APPEARED_KEY, appeared);
+    }
+
+    private boolean getRepeatableExceptionAppeared(ExtensionContext context) {
+        Boolean value = getStore(context).get(REPEATABLE_EXCEPTION_APPEARED_KEY, Boolean.class);
+        return value != null && value;
+    }
+
     /**
      * If cannot reach a minimum success target, will return true
      *
      * @param minSuccessCount - minimum success count
      * @return true/false
      */
-    private boolean isMinSuccessTargetStillReachable(final long minSuccessCount) {
-        return historyExceptionAppear.stream().filter(bool -> bool).count() < totalTestRuns - minSuccessCount;
+    private boolean isMinSuccessTargetStillReachable(ExtensionContext context, final long minSuccessCount) {
+        List<Boolean> history = getHistory(context);
+        int totalRuns = getStore(context).get(TOTAL_RUNS_KEY, Integer.class);
+        return history.stream().filter(bool -> bool).count() < totalRuns - minSuccessCount;
     }
 
     /**
@@ -231,19 +257,28 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
      */
     class TestTemplateIterator implements Iterator<TestTemplateInvocationContext> {
         int currentIndex = 0;
+        private final ExtensionContext extensionContext;
+
+        TestTemplateIterator(ExtensionContext extensionContext) {
+            this.extensionContext = extensionContext;
+        }
 
         @Override
         public boolean hasNext() {
             if (currentIndex == 0) {
                 return true;
             }
-            return historyExceptionAppear.stream().anyMatch(ex -> ex) && currentIndex < totalTestRuns;
+            List<Boolean> history = getHistory(extensionContext);
+            int totalRuns = getStore(extensionContext).get(TOTAL_RUNS_KEY, Integer.class);
+            return history.stream().anyMatch(ex -> ex) && currentIndex < totalRuns;
         }
 
         @Override
         public TestTemplateInvocationContext next() {
             //If exception appeared would wait suspend time
-            if (historyExceptionAppear.stream().anyMatch(ex -> ex) && suspend != 0L) {
+            List<Boolean> history = getHistory(extensionContext);
+            long suspend = getStore(extensionContext).get(SUSPEND_KEY, Long.class);
+            if (history.stream().anyMatch(ex -> ex) && suspend != 0L) {
                 try {
                     Thread.sleep(suspend);
                 } catch (InterruptedException e) {
@@ -251,11 +286,14 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
                 }
             }
 
-            int successfulTestRepetitionsCount = toIntExact(historyExceptionAppear.stream().filter(b -> !b).count());
+            int successfulTestRepetitionsCount = toIntExact(history.stream().filter(b -> !b).count());
             if (hasNext()) {
                 currentIndex++;
-                return new RepeatedIfExceptionsInvocationContext(currentIndex, totalTestRuns,
-                        successfulTestRepetitionsCount, minSuccess, repeatableExceptionAppeared, formatter);
+                int totalRuns = getStore(extensionContext).get(TOTAL_RUNS_KEY, Integer.class);
+                int minSuccess = getStore(extensionContext).get(MIN_SUCCESS_KEY, Integer.class);
+                boolean appeared = getRepeatableExceptionAppeared(extensionContext);
+                return new RepeatedIfExceptionsInvocationContext(currentIndex, totalRuns,
+                        successfulTestRepetitionsCount, minSuccess, appeared, formatter);
             }
             throw new NoSuchElementException();
         }

--- a/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTestExtension.java
@@ -94,12 +94,14 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
         int totalTestRuns = totalRepeats + CURRENT_RUN;
         long suspend = annotationParams.suspend();
 
-        ExtensionContext.Store store = getStore(extensionContext);
-        store.put(REPEATS_KEY, totalRepeats);
-        store.put(MIN_SUCCESS_KEY, minSuccess);
-        store.put(TOTAL_RUNS_KEY, totalTestRuns);
-        store.put(SUSPEND_KEY, suspend);
-        store.put(HISTORY_KEY, Collections.synchronizedList(new ArrayList<>()));
+        ExtensionContext.Store configStore = getConfigStore(extensionContext);
+        configStore.put(REPEATS_KEY, totalRepeats);
+        configStore.put(MIN_SUCCESS_KEY, minSuccess);
+        configStore.put(TOTAL_RUNS_KEY, totalTestRuns);
+        configStore.put(SUSPEND_KEY, suspend);
+
+        ExtensionContext.Store runStore = getRunStore(extensionContext);
+        runStore.put(HISTORY_KEY, Collections.synchronizedList(new ArrayList<>()));
 
         String displayName = extensionContext.getDisplayName();
         formatter = displayNameFormatter(annotationParams, displayName);
@@ -114,7 +116,7 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
     public void beforeTestExecution(ExtensionContext context) {
             
         //get TotalTestRuns and minSuccess from system properties
-        ExtensionContext.Store store = getStore(context);
+        ExtensionContext.Store store = getConfigStore(context);
         Integer totalRuns = store.get(TOTAL_RUNS_KEY, Integer.class);
         Integer minSuccess = store.get(MIN_SUCCESS_KEY, Integer.class);
         String strTotalRepeats = System.getProperty("totalRepeats");
@@ -161,7 +163,7 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
             return false;
         }
         Throwable exception = extensionContext.getExecutionException().get();
-        List<Class<? extends Throwable>> repeatableExceptions = getStore(extensionContext).get(REPEATABLE_EXCEPTIONS_KEY, List.class);
+        List<Class<? extends Throwable>> repeatableExceptions = getConfigStore(extensionContext).get(REPEATABLE_EXCEPTIONS_KEY, List.class);
         return isExceptionRetryable(exception, repeatableExceptions);
     }
 
@@ -183,7 +185,7 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
 
     @Override
     public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
-        List<Class<? extends Throwable>> repeatableExceptions = getStore(context).get(REPEATABLE_EXCEPTIONS_KEY, List.class);
+        List<Class<? extends Throwable>> repeatableExceptions = getConfigStore(context).get(REPEATABLE_EXCEPTIONS_KEY, List.class);
         if (!isExceptionRetryable(throwable, repeatableExceptions)) {
             System.out.printf("Test failed with exception chain [%s] which is not configured for retry. Failing fast.%n",
                     buildExceptionChain(throwable));
@@ -192,7 +194,7 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
         setRepeatableExceptionAppeared(context, true);
 
         List<Boolean> history = getHistory(context);
-        int minSuccess = getStore(context).get(MIN_SUCCESS_KEY, Integer.class);
+        int minSuccess = getConfigStore(context).get(MIN_SUCCESS_KEY, Integer.class);
         long currentSuccessCount = history.stream().filter(exceptionAppeared -> !exceptionAppeared).count();
         if (currentSuccessCount < minSuccess && isMinSuccessTargetStillReachable(context, minSuccess)) {
             throw new TestAbortedException("Do not fail completely, but repeat the test", throwable);
@@ -222,23 +224,27 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
         return String.join(" -> ", chain);
     }
 
-    private ExtensionContext.Store getStore(ExtensionContext context) {
+    private ExtensionContext.Store getConfigStore(ExtensionContext context) {
         return context.getStore(ExtensionContext.Namespace.create(getClass(), context.getRequiredTestMethod()));
+    }
+
+    private ExtensionContext.Store getRunStore(ExtensionContext context) {
+        return context.getStore(ExtensionContext.Namespace.create(getClass(), context.getRequiredTestMethod(), "run"));
     }
 
     @SuppressWarnings("unchecked")
     private List<Boolean> getHistory(ExtensionContext context) {
-        ExtensionContext.Store store = getStore(context);
+        ExtensionContext.Store store = getRunStore(context);
         return (List<Boolean>) store.getOrComputeIfAbsent(HISTORY_KEY,
                 key -> Collections.synchronizedList(new ArrayList<>()), List.class);
     }
 
     private void setRepeatableExceptionAppeared(ExtensionContext context, boolean appeared) {
-        getStore(context).put(REPEATABLE_EXCEPTION_APPEARED_KEY, appeared);
+        getRunStore(context).put(REPEATABLE_EXCEPTION_APPEARED_KEY, appeared);
     }
 
     private boolean getRepeatableExceptionAppeared(ExtensionContext context) {
-        Boolean value = getStore(context).get(REPEATABLE_EXCEPTION_APPEARED_KEY, Boolean.class);
+        Boolean value = getRunStore(context).get(REPEATABLE_EXCEPTION_APPEARED_KEY, Boolean.class);
         return value != null && value;
     }
 
@@ -250,7 +256,7 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
      */
     private boolean isMinSuccessTargetStillReachable(ExtensionContext context, final long minSuccessCount) {
         List<Boolean> history = getHistory(context);
-        int totalRuns = getStore(context).get(TOTAL_RUNS_KEY, Integer.class);
+        int totalRuns = getConfigStore(context).get(TOTAL_RUNS_KEY, Integer.class);
         return history.stream().filter(bool -> bool).count() < totalRuns - minSuccessCount;
     }
 
@@ -271,7 +277,7 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
                 return true;
             }
             List<Boolean> history = getHistory(extensionContext);
-            int totalRuns = getStore(extensionContext).get(TOTAL_RUNS_KEY, Integer.class);
+            int totalRuns = getConfigStore(extensionContext).get(TOTAL_RUNS_KEY, Integer.class);
             return history.stream().anyMatch(ex -> ex) && currentIndex < totalRuns;
         }
 
@@ -279,7 +285,7 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
         public TestTemplateInvocationContext next() {
             //If exception appeared would wait suspend time
             List<Boolean> history = getHistory(extensionContext);
-            long suspend = getStore(extensionContext).get(SUSPEND_KEY, Long.class);
+            long suspend = getConfigStore(extensionContext).get(SUSPEND_KEY, Long.class);
             if (history.stream().anyMatch(ex -> ex) && suspend != 0L) {
                 try {
                     Thread.sleep(suspend);
@@ -291,8 +297,8 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
             int successfulTestRepetitionsCount = toIntExact(history.stream().filter(b -> !b).count());
             if (hasNext()) {
                 currentIndex++;
-                int totalRuns = getStore(extensionContext).get(TOTAL_RUNS_KEY, Integer.class);
-                int minSuccess = getStore(extensionContext).get(MIN_SUCCESS_KEY, Integer.class);
+                int totalRuns = getConfigStore(extensionContext).get(TOTAL_RUNS_KEY, Integer.class);
+                int minSuccess = getConfigStore(extensionContext).get(MIN_SUCCESS_KEY, Integer.class);
                 boolean appeared = getRepeatableExceptionAppeared(extensionContext);
                 return new RepeatedIfExceptionsInvocationContext(currentIndex, totalRuns,
                         successfulTestRepetitionsCount, minSuccess, appeared, formatter);

--- a/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/RetryableTestExtension.java
@@ -100,9 +100,6 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
         configStore.put(TOTAL_RUNS_KEY, totalTestRuns);
         configStore.put(SUSPEND_KEY, suspend);
 
-        ExtensionContext.Store runStore = getRunStore(extensionContext);
-        runStore.put(HISTORY_KEY, Collections.synchronizedList(new ArrayList<>()));
-
         String displayName = extensionContext.getDisplayName();
         formatter = displayNameFormatter(annotationParams, displayName);
 
@@ -229,7 +226,11 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
     }
 
     private ExtensionContext.Store getRunStore(ExtensionContext context) {
-        return context.getStore(ExtensionContext.Namespace.create(getClass(), context.getRequiredTestMethod(), "run"));
+        ExtensionContext methodContext = context;
+        while (methodContext.getParent().isPresent() && methodContext.getParent().get().getTestMethod().isPresent()) {
+            methodContext = methodContext.getParent().get();
+        }
+        return methodContext.getStore(ExtensionContext.Namespace.create(getClass(), methodContext.getUniqueId()));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/example/testsupport/framework/utils/AllureHelper.java
+++ b/src/main/java/com/example/testsupport/framework/utils/AllureHelper.java
@@ -6,18 +6,10 @@ public final class AllureHelper {
     private AllureHelper() {}
 
     public static <T> T step(String name, Allure.ThrowableRunnable<T> runnable) {
-        try {
-            return Allure.step(name, runnable);
-        } catch (Throwable e) {
-            throw new RuntimeException("Allure step failed: " + name, e);
-        }
+        return Allure.step(name, runnable);
     }
 
     public static void step(String name, Allure.ThrowableRunnableVoid runnable) {
-        try {
-            Allure.step(name, runnable);
-        } catch (Throwable e) {
-            throw new RuntimeException("Allure step failed: " + name, e);
-        }
+        Allure.step(name, runnable);
     }
 }

--- a/src/test/java/tests/framework/FlakyTestArgumentProvider.java
+++ b/src/test/java/tests/framework/FlakyTestArgumentProvider.java
@@ -1,0 +1,25 @@
+package tests.framework;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.stream.Stream;
+
+/**
+ * Supplies arguments for {@link RetryLogicTest#parameterizedRetryTest(String, int)}
+ * covering various success and failure scenarios.
+ */
+public class FlakyTestArgumentProvider implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return Stream.of(
+                Arguments.of("immediate-success", 0),
+                Arguments.of("success-after-one-failure", 1),
+                Arguments.of("success-after-two-failures", 2),
+                Arguments.of("always-fails", -1)
+        );
+    }
+}
+

--- a/src/test/java/tests/framework/RetryLogicTest.java
+++ b/src/test/java/tests/framework/RetryLogicTest.java
@@ -1,19 +1,45 @@
 package tests.framework;
 
+import com.example.testsupport.config.EnvironmentConfig;
+import com.example.testsupport.framework.device.TestMatrixService;
+import com.example.testsupport.framework.junit.retries.RetryableParameterizedTest;
 import com.example.testsupport.framework.junit.retries.RetryableTest;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 /**
- * Demonstrates retry behaviour of {@link RetryableTest}.
- * Contains a flaky test that eventually passes and a test that
- * always fails even after all retry attempts.
+ * Demonstrates retry behaviour of {@link RetryableTest} and {@link RetryableParameterizedTest}.
+ * Contains a flaky test that eventually passes, a test that always fails,
+ * and a parameterized set of scenarios executed in parallel to surface
+ * race conditions in the retry mechanism.
  */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = RetryLogicTest.TestConfig.class)
 public class RetryLogicTest {
 
     private static final AtomicInteger flakyAttempts = new AtomicInteger();
     private static final AtomicInteger failAttempts = new AtomicInteger();
+    private static final Map<String, AtomicInteger> parameterizedTestCounters = new ConcurrentHashMap<>();
+
+    @BeforeEach
+    void resetCounters() {
+        parameterizedTestCounters.clear();
+    }
 
     /**
      * Fails on the first attempt and succeeds on the second, verifying
@@ -37,6 +63,43 @@ public class RetryLogicTest {
         int attempt = failAttempts.incrementAndGet();
         System.out.println("alwaysFailTest attempt #" + attempt);
         Assertions.fail("Persistent failure on attempt " + attempt);
+    }
+
+    /**
+     * Exercises retry behaviour under concurrent, parameterized execution.
+     * Each scenario may succeed immediately, succeed after a number of failures,
+     * or keep failing for all attempts.
+     *
+     * @param scenarioName          unique scenario identifier
+     * @param failuresBeforeSuccess number of failures before success; -1 means the scenario always fails
+     */
+    @RetryableParameterizedTest(repeats = 3, exceptions = {AssertionError.class})
+    @ArgumentsSource(FlakyTestArgumentProvider.class)
+    void parameterizedRetryTest(String scenarioName, int failuresBeforeSuccess) {
+        AtomicInteger counter = parameterizedTestCounters.computeIfAbsent(scenarioName, s -> new AtomicInteger());
+        int attempt = counter.incrementAndGet();
+        System.out.printf("%s attempt #%d%n", scenarioName, attempt);
+        if (failuresBeforeSuccess == -1 || attempt <= failuresBeforeSuccess) {
+            Assertions.fail("Scenario " + scenarioName + " failed on attempt " + attempt);
+        }
+    }
+
+    /**
+     * Minimal Spring context supplying a stubbed {@link TestMatrixService}
+     * so the built-in {@link com.example.testsupport.framework.device.DeviceProvider}
+     * used by {@link RetryableParameterizedTest} can load without external dependencies.
+     */
+    @Configuration
+    static class TestConfig {
+        @Bean
+        TestMatrixService testMatrixService() {
+            return new TestMatrixService(new EnvironmentConfig()) {
+                @Override
+                public Stream<List<Object>> getTestMatrix() {
+                    return Stream.empty();
+                }
+            };
+        }
     }
 }
 

--- a/src/test/java/tests/framework/RetryLogicTest.java
+++ b/src/test/java/tests/framework/RetryLogicTest.java
@@ -1,0 +1,42 @@
+package tests.framework;
+
+import com.example.testsupport.framework.junit.retries.RetryableTest;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Demonstrates retry behaviour of {@link RetryableTest}.
+ * Contains a flaky test that eventually passes and a test that
+ * always fails even after all retry attempts.
+ */
+public class RetryLogicTest {
+
+    private static final AtomicInteger flakyAttempts = new AtomicInteger();
+    private static final AtomicInteger failAttempts = new AtomicInteger();
+
+    /**
+     * Fails on the first attempt and succeeds on the second, verifying
+     * that a failing run can be retried and eventually pass.
+     */
+    @RetryableTest(repeats = 2, exceptions = {AssertionError.class})
+    void flakyTestShouldPassOnSuccessfulRetry() {
+        int attempt = flakyAttempts.incrementAndGet();
+        System.out.println("flakyTest attempt #" + attempt);
+        if (attempt < 2) {
+            Assertions.fail("Flaky failure on attempt " + attempt);
+        }
+    }
+
+    /**
+     * Always fails, demonstrating that a test remains failed after
+     * exhausting all retry attempts.
+     */
+    @RetryableTest(repeats = 2, exceptions = {AssertionError.class})
+    void testThatAlwaysFailsShouldRemainFailed() {
+        int attempt = failAttempts.incrementAndGet();
+        System.out.println("alwaysFailTest attempt #" + attempt);
+        Assertions.fail("Persistent failure on attempt " + attempt);
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure retryable JUnit extensions always propagate failures instead of swallowing them
- remove unnecessary try/catch wrappers from AllureHelper

## Testing
- `gradle test -x playwrightInstall -Dspring.profiles.active=spelet` *(fails: Failed to install browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fa07edbc832fadd70a50e5151dfa