### PR TITLE
feat: add Spring AOP-based retry support for flaky tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencyManagement {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'com.vaadin.external.google', module: 'android-json'
     }

--- a/src/main/java/com/example/testsupport/framework/junit/retries/RetryAspect.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/RetryAspect.java
@@ -1,0 +1,52 @@
+package com.example.testsupport.framework.junit.retries;
+
+import io.qameta.allure.Allure;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+
+@Aspect
+@Component
+public class RetryAspect {
+
+    @Around("@annotation(retryable)")
+    public Object around(ProceedingJoinPoint joinPoint, Retryable retryable) throws Throwable {
+        int attempts = retryable.attempts();
+        Class<? extends Throwable>[] retryOn = retryable.onExceptions();
+        Throwable last = null;
+
+        for (int attempt = 1; attempt <= attempts; attempt++) {
+            try {
+                int current = attempt;
+                return Allure.step(String.format("Попытка %d из %d", current, attempts), () -> {
+                    try {
+                        return joinPoint.proceed();
+                    } catch (Throwable t) {
+                        Allure.addAttachment("Ошибка", stackTrace(t));
+                        throw t;
+                    }
+                });
+            } catch (Throwable t) {
+                last = t;
+                boolean shouldRetry = Arrays.stream(retryOn)
+                        .anyMatch(ex -> ex.isAssignableFrom(t.getClass()));
+                if (!shouldRetry || attempt == attempts) {
+                    throw t;
+                }
+            }
+        }
+        throw last;
+    }
+
+    private String stackTrace(Throwable t) {
+        StringWriter sw = new StringWriter();
+        t.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+}
+

--- a/src/main/java/com/example/testsupport/framework/junit/retries/Retryable.java
+++ b/src/main/java/com/example/testsupport/framework/junit/retries/Retryable.java
@@ -1,0 +1,14 @@
+package com.example.testsupport.framework.junit.retries;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Retryable {
+    int attempts() default 3;
+    Class<? extends Throwable>[] onExceptions() default {Throwable.class};
+}
+

--- a/src/test/java/com/example/testsupport/framework/junit/retries/FlakyTestArgumentProvider.java
+++ b/src/test/java/com/example/testsupport/framework/junit/retries/FlakyTestArgumentProvider.java
@@ -1,0 +1,22 @@
+package com.example.testsupport.framework.junit.retries;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.stream.Stream;
+
+public class FlakyTestArgumentProvider implements ArgumentsProvider {
+
+    public enum Scenario { SUCCESS, FLAKY, FAIL }
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return Stream.of(
+                Arguments.of(Scenario.SUCCESS),
+                Arguments.of(Scenario.FLAKY),
+                Arguments.of(Scenario.FAIL)
+        );
+    }
+}
+

--- a/src/test/java/com/example/testsupport/framework/junit/retries/RetryLogicTest.java
+++ b/src/test/java/com/example/testsupport/framework/junit/retries/RetryLogicTest.java
@@ -1,0 +1,97 @@
+package com.example.testsupport.framework.junit.retries;
+
+import com.example.testsupport.TestApplication;
+import com.example.testsupport.framework.junit.retries.FlakyTestArgumentProvider.Scenario;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import java.io.IOException;
+
+@SpringBootTest(classes = {TestApplication.class, RetryLogicTest.Config.class})
+class RetryLogicTest {
+
+    static class DemoService {
+        private int flakyAttempts;
+        private int failAttempts;
+        private int nonRetryAttempts;
+
+        void resetFlaky() { flakyAttempts = 0; }
+        void resetFail() { failAttempts = 0; }
+        void resetNonRetry() { nonRetryAttempts = 0; }
+
+        int getFlakyAttempts() { return flakyAttempts; }
+        int getFailAttempts() { return failAttempts; }
+        int getNonRetryAttempts() { return nonRetryAttempts; }
+
+        @Retryable(attempts = 3)
+        void flakyOperation() {
+            flakyAttempts++;
+            if (flakyAttempts < 3) {
+                throw new RuntimeException("flaky");
+            }
+        }
+
+        @Retryable(attempts = 3)
+        void alwaysFailOperation() {
+            failAttempts++;
+            throw new RuntimeException("always fails");
+        }
+
+        @Retryable(onExceptions = {IOException.class})
+        void nonRetryableOperation() {
+            nonRetryAttempts++;
+            throw new AssertionError("boom");
+        }
+    }
+
+    @Autowired
+    DemoService service;
+
+    @TestConfiguration
+    static class Config {
+        @Bean
+        DemoService demoService() {
+            return new DemoService();
+        }
+    }
+
+    @Test
+    void flakyTestPassesAfterRetries() {
+        service.resetFlaky();
+        service.flakyOperation();
+        Assertions.assertEquals(3, service.getFlakyAttempts());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(FlakyTestArgumentProvider.class)
+    @Retryable(attempts = 3)
+    void parameterizedTest(Scenario scenario) {
+        switch (scenario) {
+            case SUCCESS -> { /* do nothing */ }
+            case FLAKY -> {
+                service.resetFlaky();
+                service.flakyOperation();
+                Assertions.assertEquals(3, service.getFlakyAttempts());
+            }
+            case FAIL -> {
+                service.resetFail();
+                Assertions.assertThrows(RuntimeException.class, service::alwaysFailOperation);
+                Assertions.assertEquals(3, service.getFailAttempts());
+            }
+        }
+    }
+
+    @Test
+    void exceptionFilteringWorks() {
+        service.resetNonRetry();
+        Assertions.assertThrows(AssertionError.class, service::nonRetryableOperation);
+        Assertions.assertEquals(1, service.getNonRetryAttempts());
+    }
+}
+

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.example.testsupport.framework.allure.Suite;
+import com.example.testsupport.framework.junit.retries.Retryable;
 
 import static com.example.testsupport.framework.utils.AllureHelper.step;
 
@@ -31,6 +32,7 @@ class MultilingualNavigationTest extends BaseTest {
 
     @Story("Переход на страницу казино для всех поддерживаемых языков и устройств")
     @DisplayName("Навигация на страницу казино")
+    @Retryable(attempts = 3)
     @ParameterizedTest(name = "[Устройство: {0}, Язык: {1}]")
     @ArgumentsSource(DeviceProvider.class)
     void navigateToCasinoPageOnAllLanguagesAndDevices(Device device, String languageCode) {


### PR DESCRIPTION
## Summary
- add `@Retryable` annotation and `RetryAspect` to rerun flaky tests with Allure steps
- cover retry logic with unit tests and argument provider
- enable retries in `MultilingualNavigationTest`

## Testing
- `gradle test --tests com.example.testsupport.framework.junit.retries.RetryLogicTest --no-daemon -Dspring.profiles.active=spelet-demo -x playwrightInstall`


------
https://chatgpt.com/codex/tasks/task_e_68b61b9742bc832fb58d3a813e9e2c0c