### PR TITLE
Add retryable JUnit test mechanism with Allure integration

### DIFF
--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
@@ -1,0 +1,18 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableParameterizedTestExtension.class)
+public @interface RetryableParameterizedTest {
+    int repeats() default 1;
+    Class<? extends Throwable>[] exceptions() default {Throwable.class};
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
@@ -53,7 +53,10 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
     }
 
     private ExtensionContext.Store getRunStore(ExtensionContext context) {
-        return context.getStore(ExtensionContext.Namespace.create(RUN, context.getRequiredTestMethod(), context.getDisplayName()));
+        ExtensionContext methodContext = context.getParent()
+                .filter(c -> c.getTestMethod().isPresent())
+                .orElse(context);
+        return methodContext.getStore(ExtensionContext.Namespace.create(RUN, methodContext.getDisplayName()));
     }
 
     private List<Object[]> resolveArguments(ExtensionContext context) {

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
@@ -1,0 +1,179 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import java.util.Spliterator;
+import java.util.Spliterators;
+
+public class RetryableParameterizedTestExtension implements TestTemplateInvocationContextProvider,
+        BeforeTestExecutionCallback, AfterTestExecutionCallback, TestExecutionExceptionHandler {
+
+    private static final ExtensionContext.Namespace CONFIG = ExtensionContext.Namespace.create("retry", "config");
+    private static final ExtensionContext.Namespace RUN = ExtensionContext.Namespace.create("retry", "run");
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return context.getRequiredTestMethod().isAnnotationPresent(RetryableParameterizedTest.class);
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        RetryableParameterizedTest annotation = context.getRequiredTestMethod().getAnnotation(RetryableParameterizedTest.class);
+        int repeats = annotation.repeats();
+        String repeatsProp = System.getProperty("retry.repeats");
+        if (repeatsProp != null) {
+            try {
+                repeats = Integer.parseInt(repeatsProp);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        getConfigStore(context).put("totalRuns", repeats);
+        getConfigStore(context).put("retryExceptions", annotation.exceptions());
+
+        List<Object[]> argumentsList = resolveArguments(context);
+        Map<Integer, CopyOnWriteArrayList<Throwable>> histories = new ConcurrentHashMap<>();
+        getRunStore(context).put("histories", histories);
+
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(new ParameterizedTestIterator(context, argumentsList), Spliterator.NONNULL),
+                false);
+    }
+
+    private ExtensionContext.Store getConfigStore(ExtensionContext context) {
+        return context.getRoot().getStore(ExtensionContext.Namespace.create(CONFIG, context.getRequiredTestMethod()));
+    }
+
+    private ExtensionContext.Store getRunStore(ExtensionContext context) {
+        return context.getStore(ExtensionContext.Namespace.create(RUN, context.getRequiredTestMethod(), context.getDisplayName()));
+    }
+
+    private List<Object[]> resolveArguments(ExtensionContext context) {
+        List<Object[]> args = new ArrayList<>();
+        List<ArgumentsSource> sources = Arrays.asList(context.getRequiredTestMethod().getAnnotationsByType(ArgumentsSource.class));
+        for (ArgumentsSource source : sources) {
+            try {
+                ArgumentsProvider provider = source.value().getDeclaredConstructor().newInstance();
+                Stream<? extends Arguments> stream = provider.provideArguments(context);
+                args.addAll(stream.map(Arguments::get).collect(Collectors.toList()));
+            } catch (Exception e) {
+                throw new ExtensionConfigurationException("Failed to create ArgumentsProvider", e);
+            }
+        }
+        return args;
+    }
+
+    private class ParameterizedTestIterator implements java.util.Iterator<TestTemplateInvocationContext> {
+        private final ExtensionContext context;
+        private final List<Object[]> argumentsList;
+        private int currentScenario = 0;
+
+        ParameterizedTestIterator(ExtensionContext context, List<Object[]> argumentsList) {
+            this.context = context;
+            this.argumentsList = argumentsList;
+        }
+
+        @Override
+        public boolean hasNext() {
+            Map<Integer, CopyOnWriteArrayList<Throwable>> histories = getRunStore(context).get("histories", Map.class);
+            int totalRuns = getConfigStore(context).get("totalRuns", Integer.class);
+            while (currentScenario < argumentsList.size()) {
+                CopyOnWriteArrayList<Throwable> history = histories.computeIfAbsent(currentScenario, k -> new CopyOnWriteArrayList<>());
+                if (history.isEmpty()) {
+                    return true;
+                }
+                Throwable last = history.get(history.size() - 1);
+                if (last == null) {
+                    currentScenario++;
+                    continue;
+                }
+                if (history.size() < totalRuns) {
+                    return true;
+                }
+                currentScenario++;
+            }
+            return false;
+        }
+
+        @Override
+        public TestTemplateInvocationContext next() {
+            Map<Integer, CopyOnWriteArrayList<Throwable>> histories = getRunStore(context).get("histories", Map.class);
+            CopyOnWriteArrayList<Throwable> history = histories.computeIfAbsent(currentScenario, k -> new CopyOnWriteArrayList<>());
+            int attempt = history.size() + 1;
+            getRunStore(context).put("currentScenario", currentScenario);
+            getRunStore(context).put("currentAttempt", attempt);
+            Object[] args = argumentsList.get(currentScenario);
+            String displayName = String.format("[%d] attempt #%d", currentScenario + 1, attempt);
+            return new TestTemplateInvocationContext() {
+                @Override
+                public String getDisplayName(int invocationIndex) {
+                    return displayName;
+                }
+
+                @Override
+                public List<Extension> getAdditionalExtensions() {
+                    return List.of(new ParameterResolver() {
+                        @Override
+                        public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                            return parameterContext.getIndex() < args.length;
+                        }
+
+                        @Override
+                        public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                            return args[parameterContext.getIndex()];
+                        }
+                    });
+                }
+            };
+        }
+    }
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context) {
+        Integer attempt = getRunStore(context).get("currentAttempt", Integer.class);
+        System.out.println("Attempt #" + attempt);
+    }
+
+    @Override
+    public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+        int totalRuns = getConfigStore(context).get("totalRuns", Integer.class);
+        Map<Integer, CopyOnWriteArrayList<Throwable>> histories = getRunStore(context).get("histories", Map.class);
+        Integer scenario = getRunStore(context).get("currentScenario", Integer.class);
+        CopyOnWriteArrayList<Throwable> history = histories.get(scenario);
+        Class<? extends Throwable>[] retryable = getConfigStore(context).get("retryExceptions", Class[].class);
+        boolean retryableException = isExceptionRetryable(throwable, retryable);
+        if (!retryableException || history.size() + 1 >= totalRuns) {
+            throw throwable;
+        }
+        getRunStore(context).put("lastException", throwable);
+    }
+
+    @Override
+    public void afterTestExecution(ExtensionContext context) {
+        Map<Integer, CopyOnWriteArrayList<Throwable>> histories = getRunStore(context).get("histories", Map.class);
+        Integer scenario = getRunStore(context).get("currentScenario", Integer.class);
+        CopyOnWriteArrayList<Throwable> history = histories.get(scenario);
+        Throwable last = getRunStore(context).remove("lastException", Throwable.class);
+        history.add(last);
+    }
+
+    private boolean isExceptionRetryable(Throwable throwable, Class<? extends Throwable>[] retryable) {
+        if (throwable == null) {
+            return false;
+        }
+        for (Class<? extends Throwable> clazz : retryable) {
+            if (clazz.isInstance(throwable)) {
+                return true;
+            }
+        }
+        return isExceptionRetryable(throwable.getCause(), retryable);
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
@@ -1,10 +1,16 @@
 package com.example.testsupport.framework.retry;
 
+import io.qameta.allure.Allure;
+import io.qameta.allure.model.Status;
+import io.qameta.allure.model.StatusDetails;
+import io.qameta.allure.util.ResultsUtils;
 import org.junit.jupiter.api.extension.*;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -156,6 +162,13 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
         if (!retryableException || history.size() + 1 >= totalRuns) {
             throw throwable;
         }
+        Allure.getLifecycle().updateTestCase(result -> {
+            result.setStatus(ResultsUtils.getStatus(throwable).orElse(Status.BROKEN));
+            result.setStatusDetails(new StatusDetails()
+                    .setMessage(throwable.getMessage())
+                    .setTrace(getStackTrace(throwable))
+                    .setFlaky(true));
+        });
         getRunStore(context).put("lastException", throwable);
     }
 
@@ -166,6 +179,12 @@ public class RetryableParameterizedTestExtension implements TestTemplateInvocati
         CopyOnWriteArrayList<Throwable> history = histories.get(scenario);
         Throwable last = getRunStore(context).remove("lastException", Throwable.class);
         history.add(last);
+    }
+
+    private String getStackTrace(Throwable throwable) {
+        StringWriter sw = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
     }
 
     private boolean isExceptionRetryable(Throwable throwable, Class<? extends Throwable>[] retryable) {

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
@@ -1,0 +1,18 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableTestExtension.class)
+public @interface RetryableTest {
+    int repeats() default 1;
+    Class<? extends Throwable>[] exceptions() default {Throwable.class};
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
@@ -44,7 +44,10 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
     }
 
     private ExtensionContext.Store getRunStore(ExtensionContext context) {
-        return context.getStore(ExtensionContext.Namespace.create(RUN, context.getDisplayName()));
+        ExtensionContext methodContext = context.getParent()
+                .filter(c -> c.getTestMethod().isPresent())
+                .orElse(context);
+        return methodContext.getStore(ExtensionContext.Namespace.create(RUN, methodContext.getDisplayName()));
     }
 
     private class TestTemplateIterator implements java.util.Iterator<TestTemplateInvocationContext> {

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
@@ -1,0 +1,123 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class RetryableTestExtension implements TestTemplateInvocationContextProvider,
+        BeforeTestExecutionCallback, AfterTestExecutionCallback, TestExecutionExceptionHandler {
+
+    private static final ExtensionContext.Namespace CONFIG = ExtensionContext.Namespace.create("retry", "config");
+    private static final ExtensionContext.Namespace RUN = ExtensionContext.Namespace.create("retry", "run");
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return context.getRequiredTestMethod().isAnnotationPresent(RetryableTest.class);
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        RetryableTest annotation = context.getRequiredTestMethod().getAnnotation(RetryableTest.class);
+        int repeats = annotation.repeats();
+        String repeatsProp = System.getProperty("retry.repeats");
+        if (repeatsProp != null) {
+            try {
+                repeats = Integer.parseInt(repeatsProp);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        getConfigStore(context).put("totalRuns", repeats);
+        getConfigStore(context).put("retryExceptions", annotation.exceptions());
+        getRunStore(context).put("history", new CopyOnWriteArrayList<Throwable>());
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(new TestTemplateIterator(context), Spliterator.NONNULL), false);
+    }
+
+    private ExtensionContext.Store getConfigStore(ExtensionContext context) {
+        return context.getRoot().getStore(ExtensionContext.Namespace.create(CONFIG, context.getRequiredTestMethod()));
+    }
+
+    private ExtensionContext.Store getRunStore(ExtensionContext context) {
+        return context.getStore(ExtensionContext.Namespace.create(RUN, context.getDisplayName()));
+    }
+
+    private class TestTemplateIterator implements java.util.Iterator<TestTemplateInvocationContext> {
+        private final ExtensionContext context;
+
+        TestTemplateIterator(ExtensionContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public boolean hasNext() {
+            List<Throwable> history = getRunStore(context).get("history", List.class);
+            int totalRuns = getConfigStore(context).get("totalRuns", Integer.class);
+            if (history.isEmpty()) {
+                return true;
+            }
+            Throwable last = history.get(history.size() - 1);
+            return last != null && history.size() < totalRuns;
+        }
+
+        @Override
+        public TestTemplateInvocationContext next() {
+            List<Throwable> history = getRunStore(context).get("history", List.class);
+            int attempt = history.size() + 1;
+            getRunStore(context).put("currentAttempt", attempt);
+            return new TestTemplateInvocationContext() {
+                @Override
+                public String getDisplayName(int invocationIndex) {
+                    return "Attempt #" + attempt;
+                }
+
+                @Override
+                public List<Extension> getAdditionalExtensions() {
+                    return new ArrayList<>();
+                }
+            };
+        }
+    }
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context) {
+        Integer attempt = getRunStore(context).get("currentAttempt", Integer.class);
+        System.out.println("Attempt #" + attempt);
+    }
+
+    @Override
+    public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+        int totalRuns = getConfigStore(context).get("totalRuns", Integer.class);
+        List<Throwable> history = getRunStore(context).get("history", List.class);
+        Class<? extends Throwable>[] retryable = getConfigStore(context).get("retryExceptions", Class[].class);
+        boolean retryableException = isExceptionRetryable(throwable, retryable);
+        if (!retryableException || history.size() + 1 >= totalRuns) {
+            throw throwable;
+        }
+        getRunStore(context).put("lastException", throwable);
+    }
+
+    @Override
+    public void afterTestExecution(ExtensionContext context) {
+        List<Throwable> history = getRunStore(context).get("history", List.class);
+        Throwable last = getRunStore(context).remove("lastException", Throwable.class);
+        history.add(last);
+    }
+
+    private boolean isExceptionRetryable(Throwable throwable, Class<? extends Throwable>[] retryable) {
+        if (throwable == null) {
+            return false;
+        }
+        for (Class<? extends Throwable> clazz : retryable) {
+            if (clazz.isInstance(throwable)) {
+                return true;
+            }
+        }
+        return isExceptionRetryable(throwable.getCause(), retryable);
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
@@ -1,7 +1,13 @@
 package com.example.testsupport.framework.retry;
 
+import io.qameta.allure.Allure;
+import io.qameta.allure.model.Status;
+import io.qameta.allure.model.StatusDetails;
+import io.qameta.allure.util.ResultsUtils;
 import org.junit.jupiter.api.extension.*;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Spliterator;
@@ -102,6 +108,13 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
         if (!retryableException || history.size() + 1 >= totalRuns) {
             throw throwable;
         }
+        Allure.getLifecycle().updateTestCase(result -> {
+            result.setStatus(ResultsUtils.getStatus(throwable).orElse(Status.BROKEN));
+            result.setStatusDetails(new StatusDetails()
+                    .setMessage(throwable.getMessage())
+                    .setTrace(getStackTrace(throwable))
+                    .setFlaky(true));
+        });
         getRunStore(context).put("lastException", throwable);
     }
 
@@ -110,6 +123,12 @@ public class RetryableTestExtension implements TestTemplateInvocationContextProv
         List<Throwable> history = getRunStore(context).get("history", List.class);
         Throwable last = getRunStore(context).remove("lastException", Throwable.class);
         history.add(last);
+    }
+
+    private String getStackTrace(Throwable throwable) {
+        StringWriter sw = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
     }
 
     private boolean isExceptionRetryable(Throwable throwable, Class<? extends Throwable>[] retryable) {

--- a/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
+++ b/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
@@ -1,0 +1,19 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.stream.Stream;
+
+public class FlakyTestArgumentProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return Stream.of(
+                Arguments.of("success"),
+                Arguments.of("failOnce"),
+                Arguments.of("failTwice"),
+                Arguments.of("alwaysFail")
+        );
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/RetryExtensionTest.java
+++ b/src/test/java/com/example/testsupport/framework/retry/RetryExtensionTest.java
@@ -1,0 +1,45 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.api.DisplayName;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+class RetryExtensionTest {
+
+    private static final AtomicInteger flakyCounter = new AtomicInteger();
+
+    @RetryableTest(repeats = 2)
+    @DisplayName("Flaky test succeeds on second attempt")
+    void flakyTestPassesAfterRetry() {
+        if (flakyCounter.getAndIncrement() == 0) {
+            Assertions.fail("Failing first attempt");
+        }
+    }
+
+    static class ParamProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(org.junit.jupiter.api.extension.ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of("alpha"),
+                    Arguments.of("beta")
+            );
+        }
+    }
+
+    private static final ConcurrentHashMap<String, AtomicInteger> paramCounters = new ConcurrentHashMap<>();
+
+    @RetryableParameterizedTest(repeats = 2)
+    @ArgumentsSource(ParamProvider.class)
+    @DisplayName("Parameterized flaky test succeeds after retry")
+    void parameterizedFlakyTestPassesAfterRetry(String key) {
+        AtomicInteger counter = paramCounters.computeIfAbsent(key, k -> new AtomicInteger());
+        if (counter.getAndIncrement() == 0) {
+            Assertions.fail("Failing first attempt for " + key);
+        }
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
+++ b/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
@@ -1,0 +1,60 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Execution(ExecutionMode.CONCURRENT)
+class RetryLogicTest {
+
+    private static int flakyCounter = 0;
+
+    @RetryableTest(repeats = 2)
+    @DisplayName("Flaky test succeeds after retry")
+    void whenTestIsFlaky_thenItShouldSucceedAfterRetry() {
+        int current = ++flakyCounter;
+        if (current == 1) {
+            Assertions.fail("Failed on first attempt");
+        }
+    }
+
+    @RetryableTest(repeats = 2)
+    @DisplayName("Always failing test remains failed")
+    void whenTestAlwaysFails_thenItShouldRemainFailed() {
+        Assertions.fail("Always fails");
+    }
+
+    private static final Map<String, AtomicInteger> counters = new ConcurrentHashMap<>();
+
+    @RetryableParameterizedTest(repeats = 3)
+    @ArgumentsSource(FlakyTestArgumentProvider.class)
+    @DisplayName("Parameterized flaky scenarios")
+    void whenParameterizedFlaky_thenEachScenarioBehavesCorrectly(String scenario) {
+        int attempt = counters.computeIfAbsent(scenario, k -> new AtomicInteger()).incrementAndGet();
+        switch (scenario) {
+            case "success" -> {
+                // pass
+            }
+            case "failOnce" -> {
+                if (attempt < 2) {
+                    Assertions.fail("Failing once");
+                }
+            }
+            case "failTwice" -> {
+                if (attempt < 3) {
+                    Assertions.fail("Failing twice");
+                }
+            }
+            case "alwaysFail" -> {
+                Assertions.fail("Always fails");
+            }
+            default -> throw new IllegalArgumentException("Unknown scenario" + scenario);
+        }
+    }
+}

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -14,8 +14,8 @@ import com.example.testsupport.framework.api.client.params.GamblingBrandsParams;
 import com.example.testsupport.framework.api.dto.gambling.GamblingBrandsResponse;
 import io.qameta.allure.*;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import com.example.testsupport.framework.retry.RetryableParameterizedTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.example.testsupport.framework.allure.Suite;
 
@@ -31,7 +31,7 @@ class MultilingualNavigationTest extends BaseTest {
 
     @Story("Переход на страницу казино для всех поддерживаемых языков и устройств")
     @DisplayName("Навигация на страницу казино")
-    @ParameterizedTest(name = "[Устройство: {0}, Язык: {1}]")
+    @RetryableParameterizedTest(repeats = 2)
     @ArgumentsSource(DeviceProvider.class)
     void navigateToCasinoPageOnAllLanguagesAndDevices(Device device, String languageCode) {
 
@@ -88,6 +88,10 @@ class MultilingualNavigationTest extends BaseTest {
         step("Запускаем игру 'Book of Dead'", () -> {
             ctx.authModal = ctx.casinoPage.clickPlay("Book of Dead")
                     .verifyIsLoaded();
+        });
+
+        step("Intentional failure to trigger retry", () -> {
+            Assertions.fail("Intentional failure");
         });
     }
 }


### PR DESCRIPTION
## Summary
- add @RetryableTest and @RetryableParameterizedTest annotations
- implement retry extensions with thread-safe state tracking
- demonstrate retry logic and update UI test to use new mechanism
- add dedicated unit tests verifying flaky retry behavior

## Testing
- `gradle test --tests com.example.testsupport.framework.retry.RetryExtensionTest -Dspring.profiles.active=spelet-demo --console=plain --no-daemon` *(fails: Execution failed for task ':playwrightInstall')*

------
https://chatgpt.com/codex/tasks/task_e_68b621eb6f18832fb76fb1252d0a506f