### PR TITLE
feat: add retryable test annotations

### DIFF
--- a/src/main/java/com/example/testsupport/framework/retry/RetryConfig.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryConfig.java
@@ -1,0 +1,50 @@
+package com.example.testsupport.framework.retry;
+
+import java.util.Arrays;
+
+/**
+ * Simple immutable configuration holder for retry settings.
+ */
+public record RetryConfig(int repeats, int minSuccess, long suspend,
+                          Class<? extends Throwable>[] retryOn) {
+
+    static RetryConfig from(RetryableTest annotation) {
+        int repeats = getInt("retry.repeats", annotation.repeats());
+        int minSuccess = getInt("retry.minSuccess", annotation.minSuccess());
+        long suspend = getLong("retry.suspend", annotation.suspend());
+        return new RetryConfig(repeats, minSuccess, suspend, annotation.retryOn());
+    }
+
+    static RetryConfig from(RetryableParameterizedTest annotation) {
+        int repeats = getInt("retry.repeats", annotation.repeats());
+        int minSuccess = getInt("retry.minSuccess", annotation.minSuccess());
+        long suspend = getLong("retry.suspend", annotation.suspend());
+        return new RetryConfig(repeats, minSuccess, suspend, annotation.retryOn());
+    }
+
+    private static int getInt(String key, int defaultValue) {
+        String val = System.getProperty(key);
+        return val != null ? Integer.parseInt(val) : defaultValue;
+    }
+
+    private static long getLong(String key, long defaultValue) {
+        String val = System.getProperty(key);
+        return val != null ? Long.parseLong(val) : defaultValue;
+    }
+
+    boolean isRetryable(Throwable t) {
+        return Arrays.stream(retryOn)
+                .anyMatch(cls -> isInstanceOf(t, cls));
+    }
+
+    private boolean isInstanceOf(Throwable t, Class<? extends Throwable> cls) {
+        Throwable current = t;
+        while (current != null) {
+            if (cls.isInstance(current)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryExecutor.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryExecutor.java
@@ -1,11 +1,18 @@
 package com.example.testsupport.framework.retry;
 
-import org.junit.jupiter.api.function.ThrowingSupplier;
+import io.qameta.allure.Allure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
 /**
  * Executes a callback with retry semantics defined by {@link RetryConfig}.
  */
 final class RetryExecutor {
+
+    private static final Logger log = LoggerFactory.getLogger(RetryExecutor.class);
 
     private RetryExecutor() {}
 
@@ -24,6 +31,16 @@ final class RetryExecutor {
                 if (!config.isRetryable(t) || attempts >= config.repeats()) {
                     throw t;
                 }
+
+                int currentAttempt = attempts + 1;
+                log.warn("[RETRY] Attempt {}/{} failed with '{}: {}'. Retrying...",
+                        currentAttempt, totalAttempts, t.getClass().getSimpleName(), t.getMessage());
+
+                try (StringWriter sw = new StringWriter(); PrintWriter pw = new PrintWriter(sw)) {
+                    t.printStackTrace(pw);
+                    Allure.addAttachment("Stacktrace on attempt " + currentAttempt, sw.toString());
+                }
+
                 if (config.suspend() > 0) {
                     try {
                         Thread.sleep(config.suspend());

--- a/src/main/java/com/example/testsupport/framework/retry/RetryExecutor.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryExecutor.java
@@ -1,0 +1,48 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.function.ThrowingSupplier;
+
+/**
+ * Executes a callback with retry semantics defined by {@link RetryConfig}.
+ */
+final class RetryExecutor {
+
+    private RetryExecutor() {}
+
+    static void execute(ThrowingRunnable action, RetryConfig config) throws Throwable {
+        int attempts = 0;
+        int successes = 0;
+        Throwable lastError = null;
+        int totalAttempts = config.repeats() + 1;
+
+        while (attempts < totalAttempts && successes < config.minSuccess()) {
+            try {
+                action.run();
+                successes++;
+            } catch (Throwable t) {
+                lastError = t;
+                if (!config.isRetryable(t) || attempts >= config.repeats()) {
+                    throw t;
+                }
+                if (config.suspend() > 0) {
+                    try {
+                        Thread.sleep(config.suspend());
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw ie;
+                    }
+                }
+            }
+            attempts++;
+        }
+
+        if (successes < config.minSuccess() && lastError != null) {
+            throw lastError;
+        }
+    }
+
+    @FunctionalInterface
+    interface ThrowingRunnable {
+        void run() throws Throwable;
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
@@ -1,0 +1,20 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import java.lang.annotation.*;
+
+/**
+ * Parameterized variant of {@link RetryableTest}. Each invocation with a distinct
+ * set of arguments is retried independently.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ParameterizedTest
+@ExtendWith(RetryableParameterizedTestExtension.class)
+public @interface RetryableParameterizedTest {
+    int repeats() default 0;
+    int minSuccess() default 1;
+    long suspend() default 0L;
+    Class<? extends Throwable>[] retryOn() default { Throwable.class };
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
@@ -1,0 +1,44 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Extension that provides retry support for {@link RetryableParameterizedTest}.
+ * Each parameterized invocation is retried independently.
+ */
+public class RetryableParameterizedTestExtension implements InvocationInterceptor {
+
+    @Override
+    public void interceptTestTemplateMethod(Invocation<Void> invocation,
+                                            ReflectiveInvocationContext<Method> invocationContext,
+                                            ExtensionContext extensionContext) throws Throwable {
+        RetryableParameterizedTest annotation = extensionContext.getRequiredTestMethod()
+                .getAnnotation(RetryableParameterizedTest.class);
+        if (annotation == null) {
+            invocation.proceed();
+            return;
+        }
+        RetryConfig config = RetryConfig.from(annotation);
+        Object testInstance = extensionContext.getRequiredTestInstance();
+        Method method = extensionContext.getRequiredTestMethod();
+        AtomicInteger attempt = new AtomicInteger();
+        RetryExecutor.execute(() -> {
+            int current = attempt.getAndIncrement();
+            try {
+                if (current == 0) {
+                    invocation.proceed();
+                } else {
+                    method.invoke(testInstance, invocationContext.getArguments().toArray());
+                }
+            } catch (InvocationTargetException e) {
+                throw e.getTargetException();
+            }
+        }, config);
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
@@ -1,0 +1,28 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import java.lang.annotation.*;
+
+/**
+ * Annotation that marks a regular JUnit test as retryable. Configuration can be
+ * provided via attributes or overridden using system properties with the prefix
+ * {@code retry.}. For example {@code -Dretry.repeats=2}.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Test
+@ExtendWith(RetryableTestExtension.class)
+public @interface RetryableTest {
+    /** Number of retries to perform after the initial attempt. */
+    int repeats() default 0;
+
+    /** Minimum number of successful executions required for the test to pass. */
+    int minSuccess() default 1;
+
+    /** Delay in milliseconds before the next retry attempt. */
+    long suspend() default 0L;
+
+    /** Exception types that should trigger retry logic. */
+    Class<? extends Throwable>[] retryOn() default { Throwable.class };
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
@@ -1,0 +1,43 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * JUnit 5 extension that applies retry logic to standard {@code @Test} methods
+ * annotated with {@link RetryableTest}.
+ */
+public class RetryableTestExtension implements InvocationInterceptor {
+
+    @Override
+    public void interceptTestMethod(Invocation<Void> invocation,
+                                    ReflectiveInvocationContext<Method> invocationContext,
+                                    ExtensionContext extensionContext) throws Throwable {
+        RetryableTest annotation = extensionContext.getRequiredTestMethod().getAnnotation(RetryableTest.class);
+        if (annotation == null) {
+            invocation.proceed();
+            return;
+        }
+        RetryConfig config = RetryConfig.from(annotation);
+        Object testInstance = extensionContext.getRequiredTestInstance();
+        Method method = extensionContext.getRequiredTestMethod();
+        AtomicInteger attempt = new AtomicInteger();
+        RetryExecutor.execute(() -> {
+            int current = attempt.getAndIncrement();
+            try {
+                if (current == 0) {
+                    invocation.proceed();
+                } else {
+                    method.invoke(testInstance, invocationContext.getArguments().toArray());
+                }
+            } catch (InvocationTargetException e) {
+                throw e.getTargetException();
+            }
+        }, config);
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
+++ b/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
@@ -1,0 +1,53 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Unit tests validating retry logic.
+ */
+@TestMethodOrder(OrderAnnotation.class)
+class RetryLogicTest {
+
+    private static final AtomicInteger flakyCounter = new AtomicInteger();
+
+    @RetryableTest(repeats = 2)
+    @Order(1)
+    void flakyTestSucceedsAfterRetry() {
+        int attempt = flakyCounter.getAndIncrement();
+        if (attempt < 1) {
+            Assertions.fail("flaky failure");
+        }
+    }
+
+    private static final AtomicInteger minSuccessCounter = new AtomicInteger();
+
+    @RetryableTest(repeats = 2, minSuccess = 2)
+    @Order(2)
+    void testWithMinSuccess() {
+        int attempt = minSuccessCounter.getAndIncrement();
+        if (attempt == 0) {
+            throw new RuntimeException("first attempt fails");
+        }
+        // subsequent attempts succeed
+    }
+
+    private static final ConcurrentHashMap<Integer, AtomicInteger> paramCounters = new ConcurrentHashMap<>();
+
+    @RetryableParameterizedTest(repeats = 2)
+    @ValueSource(ints = {1, 2})
+    @Order(3)
+    void parameterizedFlakyTest(int id) {
+        AtomicInteger counter = paramCounters.computeIfAbsent(id, k -> new AtomicInteger());
+        int attempt = counter.getAndIncrement();
+        if (id == 1 && attempt < 1) {
+            Assertions.fail("first parameter is flaky");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `@RetryableTest` and `@RetryableParameterizedTest` annotations
- implement retry extensions and executor with configurable attempts
- cover retry behaviour with unit tests

## Testing
- `gradle test -Dspring.profiles.active=spelet -x playwrightInstall --tests com.example.testsupport.framework.retry.RetryLogicTest`

------
https://chatgpt.com/codex/tasks/task_e_68b62d952b4c832f82d4ee20053546a8