### PR TITLE
Implement foundational retryable test framework

### DIFF
--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
@@ -1,0 +1,18 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableParameterizedTestExtension.class)
+public @interface RetryableParameterizedTest {
+    int repeats() default 1; // total attempts
+    int minSuccess() default 1;
+    long suspend() default 0L;
+    Class<? extends Throwable>[] exceptions() default {Throwable.class};
+    String name() default "[{index}] {arguments}";
+    String repeatedName() default "{displayName} (retry {currentRepetition}/{totalRepetitions})";
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
@@ -1,0 +1,169 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.opentest4j.TestAbortedException;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class RetryableParameterizedTestExtension implements TestTemplateInvocationContextProvider {
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return context.getTestMethod().isPresent() &&
+                context.getTestMethod().get().isAnnotationPresent(RetryableParameterizedTest.class);
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        Method method = context.getRequiredTestMethod();
+        RetryableParameterizedTest annotation = method.getAnnotation(RetryableParameterizedTest.class);
+        RetryConfig config = new RetryConfig(annotation.repeats(), annotation.minSuccess(), annotation.suspend(), annotation.exceptions(), annotation.name(), annotation.repeatedName());
+        getConfigStore(context).put("config", config);
+
+        List<Arguments> argumentsList = resolveArguments(context);
+        int totalRepeats = annotation.repeats();
+        List<TestTemplateInvocationContext> contexts = new ArrayList<>();
+        for (int index = 0; index < argumentsList.size(); index++) {
+            Arguments args = argumentsList.get(index);
+            String baseName = formatDisplayName(config.name(), index, args);
+            for (int attempt = 1; attempt <= totalRepeats; attempt++) {
+                contexts.add(new ParamInvocationContext(baseName, args, index, attempt, totalRepeats));
+            }
+        }
+        return contexts.stream();
+    }
+
+    private List<Arguments> resolveArguments(ExtensionContext context) {
+        Method method = context.getRequiredTestMethod();
+        return AnnotationSupport.findRepeatableAnnotations(method, org.junit.jupiter.params.provider.ArgumentsSource.class)
+                .stream()
+                .flatMap(source -> {
+                    try {
+                        ArgumentsProvider provider = source.value().getDeclaredConstructor().newInstance();
+                        if (provider instanceof AnnotationConsumer<?> consumer) {
+                            @SuppressWarnings("unchecked")
+                            AnnotationConsumer<org.junit.jupiter.params.provider.ArgumentsSource> ac = (AnnotationConsumer<org.junit.jupiter.params.provider.ArgumentsSource>) consumer;
+                            ac.accept(source);
+                        }
+                        return provider.provideArguments(context);
+                    } catch (Exception e) {
+                        throw new ExtensionConfigurationException("Failed to instantiate arguments provider", e);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    private String formatDisplayName(String pattern, int index, Arguments args) {
+        Object[] argArray = args.get();
+        String arguments = Stream.of(argArray).map(String::valueOf).collect(Collectors.joining(", "));
+        return pattern.replace("{index}", String.valueOf(index)).replace("{arguments}", arguments);
+    }
+
+    private static ExtensionContext.Store getConfigStore(ExtensionContext context) {
+        return context.getStore(ExtensionContext.Namespace.create(RetryableParameterizedTestExtension.class, context.getRequiredTestMethod()));
+    }
+
+    private static ExtensionContext.Store getRunStore(ExtensionContext context, String key) {
+        return context.getStore(ExtensionContext.Namespace.create(RetryableParameterizedTestExtension.class, key));
+    }
+
+    private static class ParamInvocationContext implements TestTemplateInvocationContext {
+        private final String baseName;
+        private final Arguments arguments;
+        private final int index;
+        private final int attempt;
+        private final int total;
+
+        ParamInvocationContext(String baseName, Arguments arguments, int index, int attempt, int total) {
+            this.baseName = baseName;
+            this.arguments = arguments;
+            this.index = index;
+            this.attempt = attempt;
+            this.total = total;
+        }
+
+        @Override
+        public String getDisplayName(int invocationIndex) {
+            if (attempt == 1) {
+                return baseName;
+            }
+            return baseName + " (retry " + attempt + "/" + total + ")";
+        }
+
+        @Override
+        public List<Extension> getAdditionalExtensions() {
+            List<Extension> extensions = new ArrayList<>();
+            extensions.add(new ParameterResolver() {
+                @Override
+                public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                    return true;
+                }
+
+                @Override
+                public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                    return arguments.get()[parameterContext.getIndex()];
+                }
+            });
+            extensions.add(new RetryExtension(baseName, attempt));
+            return extensions;
+        }
+    }
+
+    private static class RetryExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback, TestExecutionExceptionHandler {
+        private final String key;
+        private final int attempt;
+
+        RetryExtension(String key, int attempt) {
+            this.key = key;
+            this.attempt = attempt;
+        }
+
+        @Override
+        public void beforeTestExecution(ExtensionContext context) throws Exception {
+            List<Boolean> history = getRunStore(context, key).getOrComputeIfAbsent("history", k -> new ArrayList<>(), List.class);
+            if (!history.isEmpty() && !history.get(history.size() - 1)) {
+                throw new TestAbortedException("Test already passed");
+            }
+        }
+
+        @Override
+        public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+            RetryConfig config = getConfigStore(context).get("config", RetryConfig.class);
+            List<Boolean> history = getRunStore(context, key).getOrComputeIfAbsent("history", k -> new ArrayList<>(), List.class);
+            history.add(Boolean.TRUE);
+            if (history.size() < config.repeats() && isExceptionRetryable(throwable, config.exceptions())) {
+                throw new TestAbortedException("Retrying", throwable);
+            } else {
+                throw throwable;
+            }
+        }
+
+        @Override
+        public void afterTestExecution(ExtensionContext context) throws Exception {
+            List<Boolean> history = getRunStore(context, key).getOrComputeIfAbsent("history", k -> new ArrayList<>(), List.class);
+            if (history.size() < attempt) {
+                history.add(Boolean.FALSE);
+            }
+        }
+    }
+
+    private static boolean isExceptionRetryable(Throwable ex, Class<? extends Throwable>[] types) {
+        for (Class<? extends Throwable> type : types) {
+            if (type.isInstance(ex)) {
+                return true;
+            }
+        }
+        Throwable cause = ex.getCause();
+        return cause != null && isExceptionRetryable(cause, types);
+    }
+
+    private record RetryConfig(int repeats, int minSuccess, long suspend, Class<? extends Throwable>[] exceptions, String name, String repeatedName) {}
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
@@ -1,0 +1,16 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableTestExtension.class)
+public @interface RetryableTest {
+    int repeats() default 1; // total attempts
+    int minSuccess() default 1;
+    long suspend() default 0L;
+    Class<? extends Throwable>[] exceptions() default {Throwable.class};
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
@@ -1,0 +1,114 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.*;
+import org.opentest4j.TestAbortedException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class RetryableTestExtension implements TestTemplateInvocationContextProvider {
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return context.getTestMethod().isPresent() &&
+                context.getTestMethod().get().isAnnotationPresent(RetryableTest.class);
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        RetryableTest annotation = context.getRequiredTestMethod().getAnnotation(RetryableTest.class);
+        RetryConfig config = new RetryConfig(annotation.repeats(), annotation.minSuccess(), annotation.suspend(), annotation.exceptions());
+        getConfigStore(context).put("config", config);
+        int total = annotation.repeats();
+        List<TestTemplateInvocationContext> contexts = new ArrayList<>();
+        for (int i = 1; i <= total; i++) {
+            int attempt = i;
+            contexts.add(new RetryInvocationContext(context.getDisplayName(), attempt, total));
+        }
+        return contexts.stream();
+    }
+
+    private static ExtensionContext.Store getConfigStore(ExtensionContext context) {
+        return context.getStore(ExtensionContext.Namespace.create(RetryableTestExtension.class, context.getRequiredTestMethod()));
+    }
+
+    private static ExtensionContext.Store getRunStore(ExtensionContext context, String key) {
+        return context.getStore(ExtensionContext.Namespace.create(RetryableTestExtension.class, key));
+    }
+
+    private static class RetryInvocationContext implements TestTemplateInvocationContext {
+        private final String baseName;
+        private final int attempt;
+        private final int total;
+
+        RetryInvocationContext(String baseName, int attempt, int total) {
+            this.baseName = baseName;
+            this.attempt = attempt;
+            this.total = total;
+        }
+
+        @Override
+        public String getDisplayName(int invocationIndex) {
+            if (attempt == 1) {
+                return baseName;
+            }
+            return baseName + " (retry " + attempt + "/" + total + ")";
+        }
+
+        @Override
+        public List<Extension> getAdditionalExtensions() {
+            return List.of(new RetryExtension(baseName, attempt));
+        }
+    }
+
+    private static class RetryExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback, TestExecutionExceptionHandler {
+        private final String key;
+        private final int attempt;
+
+        RetryExtension(String key, int attempt) {
+            this.key = key;
+            this.attempt = attempt;
+        }
+
+        @Override
+        public void beforeTestExecution(ExtensionContext context) throws Exception {
+            List<Boolean> history = getRunStore(context, key).getOrComputeIfAbsent("history", k -> new ArrayList<>(), List.class);
+            if (!history.isEmpty() && !history.get(history.size() - 1)) {
+                throw new TestAbortedException("Test already passed");
+            }
+        }
+
+        @Override
+        public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+            RetryConfig config = getConfigStore(context).get("config", RetryConfig.class);
+            List<Boolean> history = getRunStore(context, key).getOrComputeIfAbsent("history", k -> new ArrayList<>(), List.class);
+            history.add(Boolean.TRUE);
+            if (history.size() < config.repeats() && isExceptionRetryable(throwable, config.exceptions())) {
+                throw new TestAbortedException("Retrying", throwable);
+            } else {
+                throw throwable;
+            }
+        }
+
+        @Override
+        public void afterTestExecution(ExtensionContext context) throws Exception {
+            List<Boolean> history = getRunStore(context, key).getOrComputeIfAbsent("history", k -> new ArrayList<>(), List.class);
+            if (history.size() < attempt) {
+                history.add(Boolean.FALSE);
+            }
+        }
+    }
+
+    private static boolean isExceptionRetryable(Throwable ex, Class<? extends Throwable>[] types) {
+        for (Class<? extends Throwable> type : types) {
+            if (type.isInstance(ex)) {
+                return true;
+            }
+        }
+        Throwable cause = ex.getCause();
+        return cause != null && isExceptionRetryable(cause, types);
+    }
+
+    private record RetryConfig(int repeats, int minSuccess, long suspend, Class<? extends Throwable>[] exceptions) {}
+}

--- a/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
+++ b/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
@@ -1,0 +1,19 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.stream.Stream;
+
+public class FlakyTestArgumentProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return Stream.of(
+                Arguments.of("Сценарий 'Успех с 1-й попытки'", 0),
+                Arguments.of("Сценарий 'Успех после 1 падения'", 1),
+                Arguments.of("Сценарий 'Успех после 2 падений'", 2),
+                Arguments.of("Сценарий 'Всегда падает'", -1)
+        );
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
+++ b/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
@@ -1,0 +1,37 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@DisplayName("Проверка механизма ретраев")
+@Execution(ExecutionMode.CONCURRENT)
+public class RetryLogicTest {
+
+    private static final Map<String, AtomicInteger> attemptCounters = new ConcurrentHashMap<>();
+
+    @BeforeEach
+    void resetCounters() { attemptCounters.clear(); }
+
+    @Test
+    @DisplayName("Обычный flaky-тест должен пройти после ретрая")
+    @RetryableTest(repeats = 2)
+    void whenTestIsFlaky_itShouldSucceed() {
+        int attempt = attemptCounters.computeIfAbsent("flaky_simple", k -> new AtomicInteger()).incrementAndGet();
+        if (attempt < 2) Assertions.fail("Падение на попытке " + attempt);
+    }
+
+    @DisplayName("Параметризованный flaky-тест")
+    @RetryableParameterizedTest(repeats = 3)
+    @org.junit.jupiter.params.provider.ArgumentsSource(FlakyTestArgumentProvider.class)
+    void whenParameterizedIsFlaky_eachCaseIsHandledCorrectly(String scenario, int failures) {
+        int attempt = attemptCounters.computeIfAbsent(scenario, k -> new AtomicInteger()).incrementAndGet();
+        if (failures == -1 || attempt <= failures) {
+            Assertions.fail(String.format("Сценарий '%s' падает на попытке #%d", scenario, attempt));
+        }
+    }
+}

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -14,8 +14,8 @@ import com.example.testsupport.framework.api.client.params.GamblingBrandsParams;
 import com.example.testsupport.framework.api.dto.gambling.GamblingBrandsResponse;
 import io.qameta.allure.*;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import com.example.testsupport.framework.retry.RetryableParameterizedTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.example.testsupport.framework.allure.Suite;
 
@@ -31,7 +31,7 @@ class MultilingualNavigationTest extends BaseTest {
 
     @Story("Переход на страницу казино для всех поддерживаемых языков и устройств")
     @DisplayName("Навигация на страницу казино")
-    @ParameterizedTest(name = "[Устройство: {0}, Язык: {1}]")
+    @RetryableParameterizedTest(repeats = 2, name = "[Устройство: {0}, Язык: {1}]")
     @ArgumentsSource(DeviceProvider.class)
     void navigateToCasinoPageOnAllLanguagesAndDevices(Device device, String languageCode) {
 
@@ -56,6 +56,10 @@ class MultilingualNavigationTest extends BaseTest {
         step(String.format("Подготовка тестового окружения [Устройство: %s, Язык: %s]", device, languageCode), () -> {
             setupTestEnvironment(device, languageCode);
         });
+
+        if ("lv".equals(languageCode)) {
+            Assertions.fail("Intentional failure for lv");
+        }
 
         step("Открываем главную страницу", () -> {
             ctx.mainPage = mainPageProvider.getObject();


### PR DESCRIPTION
## Summary
- add `@RetryableTest` and `@RetryableParameterizedTest` annotations with native retry extensions
- introduce concurrent-safe retry logic and sample tests demonstrating flaky behaviour
- integrate retry mechanism into `MultilingualNavigationTest` with intentionally failing LV case

## Testing
- `gradle test --tests com.example.testsupport.framework.retry.RetryLogicTest -Dspring.profiles.active=spelet` *(fails: Execution failed for task ':playwrightInstall')*

------
https://chatgpt.com/codex/tasks/task_e_68b63448ffb0832fb5292bbde378804c