### PR TITLE
feat: add retryable test framework

### DIFF
--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
@@ -1,0 +1,20 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableParameterizedTestExtension.class)
+public @interface RetryableParameterizedTest {
+    int repeats() default 1;
+    int minSuccess() default 1;
+    long suspend() default 0L;
+    Class<? extends Throwable>[] exceptions() default {Throwable.class};
+
+    String name() default "[{index}] {arguments}";
+    String repeatedName() default "{displayName} (retry {currentRepetition}/{totalRepetitions})";
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
@@ -1,0 +1,199 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.opentest4j.TestAbortedException;
+
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class RetryableParameterizedTestExtension implements TestTemplateInvocationContextProvider,
+        BeforeTestExecutionCallback, AfterTestExecutionCallback, TestExecutionExceptionHandler {
+
+    private static class RetryConfig {
+        int repeats;
+        int minSuccess;
+        long suspend;
+        Class<? extends Throwable>[] exceptions;
+        String repeatedName;
+    }
+
+    private ExtensionContext.Store getConfigStore(ExtensionContext context) {
+        return context.getStore(Namespace.create(getClass(), context.getRequiredTestMethod()));
+    }
+
+    private ExtensionContext.Store getRunStore(ExtensionContext context, String key) {
+        return context.getStore(Namespace.create(getClass(), key));
+    }
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return context.getTestMethod().isPresent();
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        Method method = context.getRequiredTestMethod();
+        RetryableParameterizedTest annotation = method.getAnnotation(RetryableParameterizedTest.class);
+        RetryConfig cfg = new RetryConfig();
+        cfg.repeats = annotation.repeats();
+        cfg.minSuccess = annotation.minSuccess();
+        cfg.suspend = annotation.suspend();
+        cfg.exceptions = annotation.exceptions();
+        cfg.repeatedName = annotation.repeatedName();
+        getConfigStore(context).put("config", cfg);
+
+        List<Arguments> arguments = new ArrayList<>();
+        for (ArgumentsSource src : method.getAnnotationsByType(ArgumentsSource.class)) {
+            try {
+                ArgumentsProvider provider = src.value().getDeclaredConstructor().newInstance();
+                provider.provideArguments(context).forEach(arguments::add);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        AtomicInteger index = new AtomicInteger();
+        return arguments.stream().flatMap(args -> {
+            int idx = index.getAndIncrement();
+            String baseName = formatName(annotation.name(), idx, args.get());
+            return StreamSupport.stream(Spliterators.spliteratorUnknownSize(new TestTemplateIterator(context, cfg, args.get(), baseName), 0), false);
+        });
+    }
+
+    private String formatName(String pattern, int index, Object[] args) {
+        String argsString = Arrays.stream(args).map(String::valueOf).collect(Collectors.joining(", "));
+        return pattern.replace("{index}", String.valueOf(index)).replace("{arguments}", argsString);
+    }
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context) {
+        RetryConfig cfg = getConfigStore(context.getParent().orElse(context)).get("config", RetryConfig.class);
+        Class<? extends Throwable>[] base = cfg.exceptions;
+        Class<? extends Throwable>[] ext = Arrays.copyOf(base, base.length + 1);
+        ext[base.length] = TestAbortedException.class;
+        cfg.exceptions = ext;
+    }
+
+    @Override
+    public void afterTestExecution(ExtensionContext context) {
+        ExtensionContext methodCtx = context.getParent().orElse(context);
+        String baseName = methodCtx.getStore(Namespace.create(getClass(), "name-mapping"))
+                .get(context.getDisplayName(), String.class);
+        ExtensionContext.Store store = getRunStore(methodCtx, baseName);
+        @SuppressWarnings("unchecked")
+        List<Boolean> history = (List<Boolean>) store.getOrComputeIfAbsent("history", k -> new ArrayList<>());
+        history.add(context.getExecutionException().isPresent());
+    }
+
+    @Override
+    public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+        ExtensionContext methodCtx = context.getParent().orElse(context);
+        RetryConfig cfg = getConfigStore(methodCtx).get("config", RetryConfig.class);
+        String baseName = methodCtx.getStore(Namespace.create(getClass(), "name-mapping"))
+                .get(context.getDisplayName(), String.class);
+        ExtensionContext.Store store = getRunStore(methodCtx, baseName);
+        @SuppressWarnings("unchecked")
+        List<Boolean> history = (List<Boolean>) store.getOrComputeIfAbsent("history", k -> new ArrayList<>());
+        if (isExceptionRetryable(throwable, cfg.exceptions) && history.size() < cfg.repeats) {
+            if (cfg.suspend > 0L) {
+                TimeUnit.MILLISECONDS.sleep(cfg.suspend);
+            }
+            throw new TestAbortedException("Retrying test", throwable);
+        }
+        throw throwable;
+    }
+
+    private boolean isExceptionRetryable(Throwable throwable, Class<? extends Throwable>[] exceptions) {
+        for (Class<? extends Throwable> ex : exceptions) {
+            if (ex.isInstance(throwable)) {
+                return true;
+            }
+        }
+        Throwable cause = throwable.getCause();
+        return cause != null && isExceptionRetryable(cause, exceptions);
+    }
+
+    private class TestTemplateIterator implements Iterator<TestTemplateInvocationContext> {
+        private final ExtensionContext methodContext;
+        private final RetryConfig cfg;
+        private final Object[] arguments;
+        private final String baseName;
+
+        TestTemplateIterator(ExtensionContext methodContext, RetryConfig cfg, Object[] arguments, String baseName) {
+            this.methodContext = methodContext;
+            this.cfg = cfg;
+            this.arguments = arguments;
+            this.baseName = baseName;
+        }
+
+        @Override
+        public boolean hasNext() {
+            ExtensionContext.Store store = getRunStore(methodContext, baseName);
+            @SuppressWarnings("unchecked")
+            List<Boolean> history = (List<Boolean>) store.getOrComputeIfAbsent("history", k -> new ArrayList<>());
+            if (history.isEmpty()) {
+                return true;
+            }
+            boolean lastFailed = history.get(history.size() - 1);
+            return lastFailed && history.size() <= cfg.repeats;
+        }
+
+        @Override
+        public TestTemplateInvocationContext next() {
+            ExtensionContext.Store store = getRunStore(methodContext, baseName);
+            @SuppressWarnings("unchecked")
+            List<Boolean> history = (List<Boolean>) store.getOrComputeIfAbsent("history", k -> new ArrayList<>());
+            int attempt = history.size() + 1;
+            int total = cfg.repeats + 1;
+            String name = baseName;
+            if (attempt > 1) {
+                name = cfg.repeatedName
+                        .replace("{displayName}", baseName)
+                        .replace("{currentRepetition}", String.valueOf(attempt - 1))
+                        .replace("{totalRepetitions}", String.valueOf(total - 1));
+            }
+            methodContext.getStore(Namespace.create(getClass(), "name-mapping")).put(name, baseName);
+            return new ParameterizedInvocationContext(arguments, name);
+        }
+    }
+
+    private static class ParameterizedInvocationContext implements TestTemplateInvocationContext {
+        private final Object[] arguments;
+        private final String displayName;
+
+        ParameterizedInvocationContext(Object[] arguments, String displayName) {
+            this.arguments = arguments;
+            this.displayName = displayName;
+        }
+
+        @Override
+        public String getDisplayName(int invocationIndex) {
+            return displayName;
+        }
+
+        @Override
+        public List<Extension> getAdditionalExtensions() {
+            Extension resolver = new ParameterResolver() {
+                @Override
+                public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                    return parameterContext.getIndex() < arguments.length;
+                }
+
+                @Override
+                public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                    return arguments[parameterContext.getIndex()];
+                }
+            };
+            return Collections.singletonList(resolver);
+        }
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
@@ -1,0 +1,17 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableTestExtension.class)
+public @interface RetryableTest {
+    int repeats() default 1; // number of retries
+    int minSuccess() default 1;
+    long suspend() default 0L;
+    Class<? extends Throwable>[] exceptions() default {Throwable.class};
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
@@ -1,0 +1,148 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.opentest4j.TestAbortedException;
+
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class RetryableTestExtension implements TestTemplateInvocationContextProvider,
+        BeforeTestExecutionCallback, AfterTestExecutionCallback, TestExecutionExceptionHandler {
+
+    private static class RetryConfig {
+        int repeats; // number of retries
+        int minSuccess;
+        long suspend;
+        Class<? extends Throwable>[] exceptions;
+    }
+
+    private ExtensionContext.Store getConfigStore(ExtensionContext context) {
+        return context.getStore(Namespace.create(getClass(), context.getRequiredTestMethod()));
+    }
+
+    private ExtensionContext.Store getRunStore(ExtensionContext context) {
+        return context.getStore(Namespace.create(getClass(), context.getDisplayName()));
+    }
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return context.getTestMethod().isPresent();
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        Method method = context.getRequiredTestMethod();
+        RetryableTest annotation = method.getAnnotation(RetryableTest.class);
+        RetryConfig cfg = new RetryConfig();
+        cfg.repeats = annotation.repeats();
+        cfg.minSuccess = annotation.minSuccess();
+        cfg.suspend = annotation.suspend();
+        cfg.exceptions = annotation.exceptions();
+        getConfigStore(context).put("config", cfg);
+
+        TestTemplateIterator iterator = new TestTemplateIterator(context, cfg);
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0), false);
+    }
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context) {
+        RetryConfig cfg = getConfigStore(context).get("config", RetryConfig.class);
+        Class<? extends Throwable>[] base = cfg.exceptions;
+        Class<? extends Throwable>[] ext = Arrays.copyOf(base, base.length + 1);
+        ext[base.length] = TestAbortedException.class;
+        cfg.exceptions = ext;
+    }
+
+    @Override
+    public void afterTestExecution(ExtensionContext context) {
+        ExtensionContext.Store store = getRunStore(context);
+        @SuppressWarnings("unchecked")
+        List<Boolean> history = (List<Boolean>) store.getOrComputeIfAbsent("history", key -> new ArrayList<>());
+        history.add(context.getExecutionException().isPresent());
+    }
+
+    @Override
+    public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+        RetryConfig cfg = getConfigStore(context).get("config", RetryConfig.class);
+        ExtensionContext.Store store = getRunStore(context);
+        @SuppressWarnings("unchecked")
+        List<Boolean> history = (List<Boolean>) store.getOrComputeIfAbsent("history", key -> new ArrayList<>());
+        if (isExceptionRetryable(throwable, cfg.exceptions) && history.size() < cfg.repeats) {
+            if (cfg.suspend > 0L) {
+                TimeUnit.MILLISECONDS.sleep(cfg.suspend);
+            }
+            throw new TestAbortedException("Retrying test", throwable);
+        }
+        throw throwable;
+    }
+
+    private boolean isExceptionRetryable(Throwable throwable, Class<? extends Throwable>[] exceptions) {
+        for (Class<? extends Throwable> ex : exceptions) {
+            if (ex.isInstance(throwable)) {
+                return true;
+            }
+        }
+        Throwable cause = throwable.getCause();
+        return cause != null && isExceptionRetryable(cause, exceptions);
+    }
+
+    private static class SimpleInvocationContext implements TestTemplateInvocationContext {
+        private final String displayName;
+
+        SimpleInvocationContext(String displayName) {
+            this.displayName = displayName;
+        }
+
+        @Override
+        public String getDisplayName(int invocationIndex) {
+            return displayName;
+        }
+
+        @Override
+        public List<Extension> getAdditionalExtensions() {
+            return Collections.emptyList();
+        }
+    }
+
+    private class TestTemplateIterator implements Iterator<TestTemplateInvocationContext> {
+        private final ExtensionContext context;
+        private final RetryConfig cfg;
+        private final String baseName;
+
+        TestTemplateIterator(ExtensionContext context, RetryConfig cfg) {
+            this.context = context;
+            this.cfg = cfg;
+            this.baseName = context.getDisplayName();
+        }
+
+        @Override
+        public boolean hasNext() {
+            ExtensionContext.Store store = getRunStore(context);
+            @SuppressWarnings("unchecked")
+            List<Boolean> history = (List<Boolean>) store.getOrComputeIfAbsent("history", key -> new ArrayList<>());
+            if (history.isEmpty()) {
+                return true; // first run
+            }
+            boolean lastFailed = history.get(history.size() - 1);
+            return lastFailed && history.size() <= cfg.repeats;
+        }
+
+        @Override
+        public TestTemplateInvocationContext next() {
+            ExtensionContext.Store store = getRunStore(context);
+            @SuppressWarnings("unchecked")
+            List<Boolean> history = (List<Boolean>) store.getOrComputeIfAbsent("history", key -> new ArrayList<>());
+            int attempt = history.size() + 1;
+            int total = cfg.repeats + 1;
+            String name = baseName;
+            if (attempt > 1) {
+                name = String.format("%s (retry %d/%d)", baseName, attempt - 1, total - 1);
+            }
+            return new SimpleInvocationContext(name);
+        }
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
+++ b/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
@@ -1,0 +1,19 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.stream.Stream;
+
+public class FlakyTestArgumentProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return Stream.of(
+                Arguments.of("Сценарий 'Успех с 1-й попытки'", 0),
+                Arguments.of("Сценарий 'Успех после 1 падения'", 1),
+                Arguments.of("Сценарий 'Успех после 2 падений'", 2),
+                Arguments.of("Сценарий 'Всегда падает'", -1)
+        );
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
+++ b/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
@@ -1,0 +1,37 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@DisplayName("Проверка механизма ретраев")
+@Execution(ExecutionMode.CONCURRENT)
+public class RetryLogicTest {
+
+    private static final Map<String, AtomicInteger> attemptCounters = new ConcurrentHashMap<>();
+
+    @BeforeEach
+    void resetCounters() { attemptCounters.clear(); }
+
+    @Test
+    @DisplayName("Обычный flaky-тест должен пройти после ретрая")
+    @RetryableTest(repeats = 2)
+    void whenTestIsFlaky_itShouldSucceed() {
+        int attempt = attemptCounters.computeIfAbsent("flaky_simple", k -> new AtomicInteger()).incrementAndGet();
+        if (attempt < 2) Assertions.fail("Падение на попытке " + attempt);
+    }
+
+    @DisplayName("Параметризованный flaky-тест")
+    @RetryableParameterizedTest(repeats = 3)
+    @ArgumentsSource(FlakyTestArgumentProvider.class)
+    void whenParameterizedIsFlaky_eachCaseIsHandledCorrectly(String scenario, int failures) {
+        int attempt = attemptCounters.computeIfAbsent(scenario, k -> new AtomicInteger()).incrementAndGet();
+        if (failures == -1 || attempt <= failures) {
+            Assertions.fail(String.format("Сценарий '%s' падает на попытке #%d", scenario, attempt));
+        }
+    }
+}

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -14,8 +14,8 @@ import com.example.testsupport.framework.api.client.params.GamblingBrandsParams;
 import com.example.testsupport.framework.api.dto.gambling.GamblingBrandsResponse;
 import io.qameta.allure.*;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import com.example.testsupport.framework.retry.RetryableParameterizedTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.example.testsupport.framework.allure.Suite;
 
@@ -31,7 +31,7 @@ class MultilingualNavigationTest extends BaseTest {
 
     @Story("Переход на страницу казино для всех поддерживаемых языков и устройств")
     @DisplayName("Навигация на страницу казино")
-    @ParameterizedTest(name = "[Устройство: {0}, Язык: {1}]")
+    @RetryableParameterizedTest(repeats = 2, name = "[Устройство: {0}, Язык: {1}]")
     @ArgumentsSource(DeviceProvider.class)
     void navigateToCasinoPageOnAllLanguagesAndDevices(Device device, String languageCode) {
 
@@ -43,6 +43,10 @@ class MultilingualNavigationTest extends BaseTest {
             GamblingBrandsResponse gamblingBrandsResponse;
         }
         final TestContext ctx = new TestContext();
+
+        if ("lv".equals(languageCode)) {
+            step("Intentional failure for lv", () -> Assertions.fail("Broken locator for lv"));
+        }
 
         step("Получаем список брендов через API", () -> {
             var params = GamblingBrandsParams.builder()


### PR DESCRIPTION
## Summary
- add `@RetryableTest` and `@RetryableParameterizedTest` annotations with supporting extensions
- provide flaky test argument provider and diagnostic tests verifying retry logic
- integrate retryable parameterized test into multilingual navigation UI test with intentional failure scenario

## Testing
- `gradle test -Dspring.profiles.active=spelet --tests com.example.testsupport.framework.retry.RetryLogicTest -x playwrightInstall --no-daemon` *(fails: Resolve files of configuration 'classpath' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b63448ffb0832fb5292bbde378804c