### PR TITLE
feat: add retryable test infrastructure

### DIFF
--- a/src/main/java/com/example/testsupport/framework/retry/Retryable.java
+++ b/src/main/java/com/example/testsupport/framework/retry/Retryable.java
@@ -1,0 +1,18 @@
+package com.example.testsupport.framework.retry;
+
+import java.lang.annotation.*;
+
+/**
+ * Включает механизм перезапуска для любого теста JUnit 5 (@Test, @ParameterizedTest, etc.).
+ * Должна использоваться вместе с {@code @ExtendWith(RetryableExtension.class)} на уровне класса или метода.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Retryable {
+    /** Количество перезапусков после первой неудачной попытки. */
+    int repeats() default 1;
+    /** Задержка в миллисекундах перед следующим перезапуском. */
+    long suspend() default 0L;
+    /** Массив типов исключений, которые вызывают перезапуск. */
+    Class<? extends Throwable>[] onExceptions() default {Throwable.class};
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableExtension.java
@@ -1,0 +1,114 @@
+package com.example.testsupport.framework.retry;
+
+import io.qameta.allure.Allure;
+import io.qameta.allure.model.Status;
+import io.qameta.allure.model.StepResult;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public class RetryableExtension implements InvocationInterceptor {
+
+    @Override
+    public void interceptTestMethod(Invocation<Void> invocation,
+                                    ReflectiveInvocationContext<Method> invocationContext,
+                                    ExtensionContext extensionContext) throws Throwable {
+        Optional<Retryable> annotation = findAnnotation(extensionContext);
+        if (annotation.isEmpty()) {
+            invocation.proceed();
+            return;
+        }
+        executeWithRetries(invocation, invocationContext, extensionContext, annotation.get());
+    }
+
+    @Override
+    public void interceptTestTemplateMethod(Invocation<Void> invocation,
+                                            ReflectiveInvocationContext<Method> invocationContext,
+                                            ExtensionContext extensionContext) throws Throwable {
+        // Эта же логика работает и для параметризованных тестов
+        interceptTestMethod(invocation, invocationContext, extensionContext);
+    }
+
+    private void executeWithRetries(Invocation<Void> invocation,
+                                    ReflectiveInvocationContext<Method> invocationContext,
+                                    ExtensionContext extensionContext,
+                                    Retryable annotation) throws Throwable {
+        int repeats = annotation.repeats();
+        long suspend = annotation.suspend();
+        Class<? extends Throwable>[] exceptions = annotation.onExceptions();
+        Throwable lastError = null;
+
+        Method method = invocationContext.getExecutable();
+        Object target = extensionContext.getRequiredTestInstance();
+        Object[] args = invocationContext.getArguments().toArray();
+
+        for (int attempt = 1; attempt <= repeats + 1; attempt++) {
+            try {
+                String stepName = String.format("Попытка %d из %d", attempt, repeats + 1);
+                String stepId = java.util.UUID.randomUUID().toString();
+                Allure.getLifecycle().startStep(stepId, new StepResult().setName(stepName));
+                try {
+                    if (attempt == 1) {
+                        invocation.proceed();
+                    } else {
+                        method.invoke(target, args);
+                    }
+                    Allure.getLifecycle().updateStep(stepId, s -> s.setStatus(Status.PASSED));
+                } catch (Throwable t) {
+                    Allure.getLifecycle().updateStep(stepId, s -> s.setStatus(Status.FAILED));
+                    throw unwrapInvocationTargetException(t);
+                } finally {
+                    Allure.getLifecycle().stopStep(stepId);
+                }
+                return; // Успех! Выходим.
+            } catch (Throwable t) {
+                lastError = t;
+                if (!isExceptionRetryable(t, exceptions) || attempt > repeats) {
+                    throw t; // Попытки кончились или не тот тип ошибки - падаем
+                }
+
+                // Логируем ошибку и готовимся к перезапуску
+                String stackTrace = getStackTrace(t);
+                Allure.addAttachment(String.format("Ошибка на попытке %d", attempt), stackTrace);
+                System.err.printf("[RETRY] Попытка %d провалена: %s. Перезапускаем...%n", attempt, t.getMessage());
+
+                if (suspend > 0) {
+                    Thread.sleep(suspend);
+                }
+            }
+        }
+        throw lastError;
+    }
+
+    private Throwable unwrapInvocationTargetException(Throwable t) {
+        if (t instanceof java.lang.reflect.InvocationTargetException ex && ex.getTargetException() != null) {
+            return ex.getTargetException();
+        }
+        return t;
+    }
+
+    // --- Вспомогательные методы ---
+    private Optional<Retryable> findAnnotation(ExtensionContext context) {
+        return context.getElement()
+            .map(el -> el.getAnnotation(Retryable.class));
+    }
+
+    private boolean isExceptionRetryable(Throwable throwable, Class<? extends Throwable>[] retryableExceptions) {
+        if (throwable == null) return false;
+        for (Class<? extends Throwable> ex : retryableExceptions) {
+            if (ex.isAssignableFrom(throwable.getClass())) return true;
+        }
+        return isExceptionRetryable(throwable.getCause(), retryableExceptions);
+    }
+
+    private String getStackTrace(Throwable t) {
+        StringWriter sw = new StringWriter();
+        t.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
+++ b/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
@@ -1,0 +1,73 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@DisplayName("Проверка механизма ретраев (InvocationInterceptor)")
+@ExtendWith(RetryableExtension.class)
+public class RetryLogicTest {
+
+    private static final Map<String, AtomicInteger> counters = new ConcurrentHashMap<>();
+
+    @BeforeEach
+    void resetCounters() {
+        counters.clear();
+    }
+
+    @Test
+    @DisplayName("Flaky-тест должен пройти после 1 перезапуска")
+    @Retryable(repeats = 1)
+    void whenTestIsFlaky_itShouldSucceed() {
+        int attempt = counters.computeIfAbsent("flaky", k -> new AtomicInteger(0)).incrementAndGet();
+        System.out.printf("Flaky-тест, попытка #%d%n", attempt);
+        if (attempt < 2) {
+            Assertions.fail("Падение на попытке " + attempt);
+        }
+    }
+
+    @Test
+    @DisplayName("Тест, который всегда падает, должен остаться FAILED")
+    @Retryable(repeats = 2)
+    void whenTestAlwaysFails_itShouldRemainFailed() {
+        Assertions.assertThrows(AssertionError.class, () -> {
+            int attempt = counters.computeIfAbsent("alwaysFails", k -> new AtomicInteger(0)).incrementAndGet();
+            System.out.printf("Always-fails тест, попытка #%d%n", attempt);
+            Assertions.fail("Постоянное падение на попытке " + attempt);
+        });
+        // Проверяем, что было ровно 3 попытки (1 + 2 ретрая)
+        Assertions.assertEquals(3, counters.get("alwaysFails").get());
+    }
+
+    @DisplayName("Параметризованный flaky-тест")
+    @ParameterizedTest
+    @ValueSource(strings = {"A", "B"})
+    @Retryable(repeats = 2)
+    void whenParameterizedIsFlaky_invocationsAreIsolated(String scenario) {
+        int attempt = counters.computeIfAbsent(scenario, k -> new AtomicInteger(0)).incrementAndGet();
+        System.out.printf("Параметризованный тест (сценарий %s), попытка #%d%n", scenario, attempt);
+
+        // Только сценарий A является "flaky"
+        if (scenario.equals("A") && attempt < 2) {
+            Assertions.fail("Сценарий A падает на попытке " + attempt);
+        }
+    }
+
+    @Test
+    @DisplayName("Фильтр по исключениям не должен перезапускать тест с другой ошибкой")
+    @Retryable(repeats = 5, onExceptions = {IOException.class}) // Ждем только IOException
+    void whenExceptionTypeDoesNotMatch_itShouldNotRetry() {
+         Assertions.assertThrows(AssertionError.class, () -> {
+            counters.computeIfAbsent("wrongException", k -> new AtomicInteger(0)).incrementAndGet();
+            Assertions.fail("Эта ошибка не IOException, ретрая быть не должно");
+        });
+        // Проверяем, что была ровно 1 попытка
+        Assertions.assertEquals(1, counters.get("wrongException").get());
+    }
+}

--- a/src/test/java/tests/BaseTest.java
+++ b/src/test/java/tests/BaseTest.java
@@ -6,6 +6,7 @@ import com.example.testsupport.framework.device.Device;
 import com.example.testsupport.framework.listeners.PlaywrightExtension;
 import com.example.testsupport.framework.localization.LocalizationService;
 import com.example.testsupport.framework.allure.CustomSuiteExtension;
+import com.example.testsupport.framework.retry.RetryableExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,7 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import static com.example.testsupport.framework.utils.AllureHelper.step;
 
 @SpringBootTest(classes = TestApplication.class)
-@ExtendWith({PlaywrightExtension.class, CustomSuiteExtension.class})
+@ExtendWith({PlaywrightExtension.class, CustomSuiteExtension.class, RetryableExtension.class})
 public abstract class BaseTest {
 
     @Autowired protected PlaywrightManager playwrightManager;

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.example.testsupport.framework.allure.Suite;
+import com.example.testsupport.framework.retry.Retryable;
 
 import static com.example.testsupport.framework.utils.AllureHelper.step;
 
@@ -33,6 +34,7 @@ class MultilingualNavigationTest extends BaseTest {
     @DisplayName("Навигация на страницу казино")
     @ParameterizedTest(name = "[Устройство: {0}, Язык: {1}]")
     @ArgumentsSource(DeviceProvider.class)
+    @Retryable(repeats = 2)
     void navigateToCasinoPageOnAllLanguagesAndDevices(Device device, String languageCode) {
 
         final class TestContext {


### PR DESCRIPTION
## Summary
- add @Retryable annotation and RetryableExtension using InvocationInterceptor
- cover retry behavior with unit tests
- enable retry extension for UI tests

## Testing
- `gradle test --tests com.example.testsupport.framework.retry.RetryLogicTest -Dspring.profiles.active=spelet -x playwrightInstall`


------
https://chatgpt.com/codex/tasks/task_e_68b645e6ac1c832f8a0b7097935dc285