### PR TITLE
feat: add retry test scaffolding

### DIFF
--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
@@ -1,0 +1,48 @@
+package com.example.testsupport.framework.retry;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+/**
+ * Marker annotation that enables retry logic for parameterised tests.
+ * <p>
+ * At this stage the underlying extension provides a single execution for each
+ * argument set supplied by {@link #source()} without any retry behaviour.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableParameterizedTestExtension.class)
+public @interface RetryableParameterizedTest {
+    /** Number of retry attempts after the first run. */
+    int repeats() default 1;
+
+    /** Minimum number of successful executions required. */
+    int minSuccess() default 1;
+
+    /** Delay in milliseconds between attempts. */
+    long suspend() default 0L;
+
+    /** Exceptions that trigger a retry. */
+    Class<? extends Throwable>[] exceptions() default {Throwable.class};
+
+    /**
+     * Display name for individual invocations, following the same rules as
+     * {@code @ParameterizedTest}.
+     */
+    String name() default "[{index}] {arguments}";
+
+    /**
+     * Display name for repeated attempts. Not used in the current stub
+     * implementation but kept for future development.
+     */
+    String repeatedName() default "{displayName} (retry {currentRepetition}/{totalRepetitions})";
+
+    /** Provides arguments for the test. */
+    Class<? extends ArgumentsProvider> source();
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
@@ -1,0 +1,55 @@
+package com.example.testsupport.framework.retry;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+/**
+ * Placeholder extension for {@link RetryableParameterizedTest}.
+ * <p>
+ * It invokes the underlying test once for each set of arguments provided by
+ * the configured {@link ArgumentsProvider}. No retry logic is performed at this
+ * stage.
+ */
+public class RetryableParameterizedTestExtension implements TestTemplateInvocationContextProvider {
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return context.getTestMethod().isPresent();
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        Method testMethod = context.getRequiredTestMethod();
+        RetryableParameterizedTest annotation = testMethod.getAnnotation(RetryableParameterizedTest.class);
+        try {
+            ArgumentsProvider provider = annotation.source().getDeclaredConstructor().newInstance();
+            Stream<? extends Arguments> args = provider.provideArguments(context);
+            return args.map(arguments -> new TestTemplateInvocationContext() {
+                @Override
+                public List<Extension> getAdditionalExtensions() {
+                    return List.of(new ParameterResolver() {
+                        @Override
+                        public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                            return true;
+                        }
+
+                        @Override
+                        public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                            return arguments.get()[parameterContext.getIndex()];
+                        }
+                    });
+                }
+            });
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to provide arguments", e);
+        }
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
@@ -1,0 +1,33 @@
+package com.example.testsupport.framework.retry;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Marker annotation that enables retry logic for a regular JUnit test.
+ * <p>
+ * At this stage the corresponding extension simply executes the test once
+ * without any retry behaviour. Full retry capabilities will be implemented in
+ * further development stages.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableTestExtension.class)
+public @interface RetryableTest {
+    /** Number of retry attempts after the first run. */
+    int repeats() default 1;
+
+    /** Minimum number of successful executions required. */
+    int minSuccess() default 1;
+
+    /** Delay in milliseconds between attempts. */
+    long suspend() default 0L;
+
+    /** Exceptions that trigger a retry. */
+    Class<? extends Throwable>[] exceptions() default {Throwable.class};
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
@@ -1,0 +1,25 @@
+package com.example.testsupport.framework.retry;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+/**
+ * Placeholder extension for {@link RetryableTest}.
+ * <p>
+ * For the initial TDD stage this extension simply invokes the underlying test
+ * exactly once without performing any retry logic. The full retry mechanism
+ * will be implemented in subsequent stages.
+ */
+public class RetryableTestExtension implements TestTemplateInvocationContextProvider {
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return context.getTestMethod().isPresent();
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        return Stream.of(new TestTemplateInvocationContext() {});
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
+++ b/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
@@ -1,0 +1,22 @@
+package com.example.testsupport.framework.retry;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+/**
+ * Provides a predefined set of scenarios used to verify retry behaviour in
+ * {@link RetryLogicTest}.
+ */
+public class FlakyTestArgumentProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return Stream.of(
+                Arguments.of("Успех с 1-й попытки", 0),
+                Arguments.of("Успех после 1 падения", 1),
+                Arguments.of("Успех после 2 падений", 2),
+                Arguments.of("Всегда падает", -1)
+        );
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
+++ b/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
@@ -1,0 +1,85 @@
+package com.example.testsupport.framework.retry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+/**
+ * Diagnostic test suite that specifies and verifies retry behaviour.
+ * <p>
+ * The tests are executed concurrently to immediately highlight potential
+ * thread-safety issues within the retry mechanism.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+class RetryLogicTest {
+
+    private static final Map<String, AtomicInteger> attemptCounters = new ConcurrentHashMap<>();
+
+    @BeforeEach
+    void resetCounters() {
+        attemptCounters.clear();
+    }
+
+    @Test
+    @DisplayName("Flaky test should eventually succeed")
+    @RetryableTest(repeats = 2, exceptions = {AssertionError.class})
+    void whenTestIsFlaky_itShouldSucceed() {
+        int attempt = attemptCounters.computeIfAbsent("flaky_simple", k -> new AtomicInteger()).incrementAndGet();
+        if (attempt < 2) {
+            Assertions.fail("flaky failure");
+        }
+    }
+
+    @Test
+    @DisplayName("Always failing test should remain failed")
+    @RetryableTest(repeats = 2, exceptions = {AssertionError.class})
+    void whenTestAlwaysFails_itShouldRemainFailed() {
+        AssertionError error = assertThrows(AssertionError.class, () -> {
+            int attempt = attemptCounters
+                    .computeIfAbsent("always_fails_simple", k -> new AtomicInteger())
+                    .incrementAndGet();
+            Assertions.fail("always fails" + attempt);
+        });
+        assertEquals(3, attemptCounters.get("always_fails_simple").get());
+        throw error;
+    }
+
+    @DisplayName("Parameterized flaky scenarios are handled per case")
+    @RetryableParameterizedTest(
+            repeats = 3,
+            source = FlakyTestArgumentProvider.class,
+            exceptions = {AssertionError.class})
+    void whenParameterizedIsFlaky_eachCaseIsHandledCorrectly(String scenario, int failures) {
+        AtomicInteger counter = attemptCounters.computeIfAbsent(scenario, k -> new AtomicInteger());
+        int attempt = counter.incrementAndGet();
+        if (failures == -1) {
+            Assertions.fail("always fails");
+        } else if (attempt <= failures + 1) {
+            Assertions.fail("flaky attempt " + attempt);
+        }
+    }
+
+    @Test
+    @DisplayName("Non-matching exception types should not trigger retries")
+    @RetryableTest(repeats = 5, exceptions = {IOException.class})
+    void whenExceptionTypeDoesNotMatch_itShouldNotRetry() {
+        AssertionError error = assertThrows(AssertionError.class, () -> {
+            int attempt = attemptCounters
+                    .computeIfAbsent("exception_filter", k -> new AtomicInteger())
+                    .incrementAndGet();
+            Assertions.fail("unexpected assertion" + attempt);
+        });
+        assertEquals(1, attemptCounters.get("exception_filter").get());
+        throw error;
+    }
+}


### PR DESCRIPTION
## Summary
- add `@RetryableTest` and `@RetryableParameterizedTest` annotations with configuration options
- provide stub extensions that run test templates once without retry logic
- add diagnostic `RetryLogicTest` and supporting `FlakyTestArgumentProvider`

## Testing
- `gradle test --tests "com.example.testsupport.framework.retry.RetryLogicTest" -Dspring.profiles.active=spelet -x playwrightInstall` *(fails: There were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b64e7acb30832f9c8387b2dca27d7f