### PR TITLE
feat: add retry annotations and diagnostics

### DIFF
--- a/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
+++ b/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
@@ -1,0 +1,22 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.stream.Stream;
+
+/**
+ * Provides arguments for {@link RetryLogicTest} showcasing different flaky scenarios.
+ */
+public class FlakyTestArgumentProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return Stream.of(
+                Arguments.of("Успех с 1-й попытки", 0),
+                Arguments.of("Успех после 1 падения", 1),
+                Arguments.of("Успех после 2 падений", 2),
+                Arguments.of("Всегда падает", -1)
+        );
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
+++ b/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
@@ -1,0 +1,71 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Diagnostic test suite describing the expected behaviour of retry mechanism.
+ * At this stage the extension logic is not implemented, so most tests are
+ * expected to fail on their first attempt.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+class RetryLogicTest {
+
+    private static final Map<String, AtomicInteger> attemptCounters = new ConcurrentHashMap<>();
+
+    @BeforeEach
+    void reset() {
+        attemptCounters.clear();
+    }
+
+    @Test
+    @DisplayName("Flaky test should eventually succeed")
+    @RetryableTest(repeats = 2, exceptions = {AssertionError.class})
+    void whenTestIsFlaky_itShouldSucceed() {
+        int attempt = attemptCounters.computeIfAbsent("flaky_simple", k -> new AtomicInteger()).incrementAndGet();
+        if (attempt < 2) {
+            fail("Intentional failure to simulate flakiness");
+        }
+    }
+
+    @Test
+    @DisplayName("Always failing test should remain failed")
+    @RetryableTest(repeats = 2, exceptions = {AssertionError.class})
+    void whenTestAlwaysFails_itShouldRemainFailed() {
+        AtomicInteger counter = attemptCounters.computeIfAbsent("always_fails_simple", k -> new AtomicInteger());
+        assertThrows(AssertionError.class, () -> {
+            counter.incrementAndGet();
+            fail("Always failing");
+        });
+        assertEquals(3, counter.get());
+    }
+
+    @DisplayName("Flaky parameterized scenarios are handled separately")
+    @RetryableParameterizedTest(repeats = 3, source = FlakyTestArgumentProvider.class, exceptions = {AssertionError.class})
+    void whenParameterizedIsFlaky_eachCaseIsHandledCorrectly(String scenario, int failures) {
+        int attempt = attemptCounters.computeIfAbsent(scenario, k -> new AtomicInteger()).incrementAndGet();
+        if (failures == -1 || attempt <= failures) {
+            fail("Intentional failure for scenario: " + scenario);
+        }
+    }
+
+    @Test
+    @DisplayName("Should not retry when exception type does not match")
+    @RetryableTest(repeats = 5, exceptions = {IOException.class})
+    void whenExceptionTypeDoesNotMatch_itShouldNotRetry() {
+        AtomicInteger counter = attemptCounters.computeIfAbsent("exception_mismatch", k -> new AtomicInteger());
+        assertThrows(AssertionError.class, () -> {
+            counter.incrementAndGet();
+            fail("Assertion error");
+        });
+        assertEquals(1, counter.get());
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
+++ b/src/test/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
@@ -1,0 +1,40 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation to enable retry logic for parameterized tests.
+ * Data source should be provided explicitly via {@link #source()}.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableParameterizedTestExtension.class)
+public @interface RetryableParameterizedTest {
+    int repeats() default 1;
+    int minSuccess() default 1;
+    long suspend() default 0L;
+    Class<? extends Throwable>[] exceptions() default { Throwable.class };
+
+    /**
+     * Display name pattern for each set of parameters.
+     */
+    String name() default "[{index}] {arguments}";
+
+    /**
+     * Display name pattern for repeated attempts.
+     */
+    String repeatedName() default "{displayName} (retry {currentRepetition}/{totalRepetitions})";
+
+    /**
+     * Provider class that supplies arguments for the parameterized test.
+     */
+    Class<? extends ArgumentsProvider> source();
+}

--- a/src/test/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
+++ b/src/test/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
@@ -1,0 +1,77 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Stub extension for {@link RetryableParameterizedTest}. It executes each set of
+ * parameters exactly once without any retry logic.
+ */
+public class RetryableParameterizedTestExtension implements TestTemplateInvocationContextProvider {
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return true;
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        Method testMethod = context.getRequiredTestMethod();
+        RetryableParameterizedTest annotation = testMethod.getAnnotation(RetryableParameterizedTest.class);
+        ArgumentsProvider provider;
+        try {
+            provider = annotation.source().getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to instantiate arguments provider", e);
+        }
+        Stream<? extends Arguments> argsStream;
+        try {
+            argsStream = provider.provideArguments(context);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to obtain arguments", e);
+        }
+        AtomicInteger index = new AtomicInteger(0);
+        return argsStream.map(arguments -> createInvocationContext(arguments, annotation.name(), index.getAndIncrement()));
+    }
+
+    private TestTemplateInvocationContext createInvocationContext(Arguments arguments, String namePattern, int index) {
+        Object[] args = arguments.get();
+        String argumentsString = Arrays.stream(args).map(String::valueOf).collect(Collectors.joining(", "));
+        String displayName = namePattern.replace("{index}", String.valueOf(index)).replace("{arguments}", argumentsString);
+        return new TestTemplateInvocationContext() {
+            @Override
+            public String getDisplayName(int invocationIndex) {
+                return displayName;
+            }
+
+            @Override
+            public List<Extension> getAdditionalExtensions() {
+                return Collections.singletonList(new ParameterResolver() {
+                    @Override
+                    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                        return parameterContext.getIndex() < args.length;
+                    }
+
+                    @Override
+                    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                        return args[parameterContext.getIndex()];
+                    }
+                });
+            }
+        };
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/RetryableTest.java
+++ b/src/test/java/com/example/testsupport/framework/retry/RetryableTest.java
@@ -1,0 +1,38 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation that enables retry logic for standard tests.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableTestExtension.class)
+public @interface RetryableTest {
+    /**
+     * Number of additional attempts after the first run.
+     */
+    int repeats() default 1;
+
+    /**
+     * Minimum number of successful executions required to mark test as passed.
+     */
+    int minSuccess() default 1;
+
+    /**
+     * Delay between attempts in milliseconds.
+     */
+    long suspend() default 0L;
+
+    /**
+     * Exception types that should trigger a retry.
+     */
+    Class<? extends Throwable>[] exceptions() default { Throwable.class };
+}

--- a/src/test/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
+++ b/src/test/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
@@ -1,0 +1,37 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Stub extension for {@link RetryableTest}. At this stage it simply runs the
+ * underlying test once without any retry logic.
+ */
+public class RetryableTestExtension implements TestTemplateInvocationContextProvider {
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return true;
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        return Stream.of(new TestTemplateInvocationContext() {
+            @Override
+            public String getDisplayName(int invocationIndex) {
+                return context.getDisplayName();
+            }
+
+            @Override
+            public List<Extension> getAdditionalExtensions() {
+                return Collections.emptyList();
+            }
+        });
+    }
+}

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -14,8 +14,7 @@ import com.example.testsupport.framework.api.client.params.GamblingBrandsParams;
 import com.example.testsupport.framework.api.dto.gambling.GamblingBrandsResponse;
 import io.qameta.allure.*;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import com.example.testsupport.framework.retry.RetryableParameterizedTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.example.testsupport.framework.allure.Suite;
 
@@ -31,9 +30,12 @@ class MultilingualNavigationTest extends BaseTest {
 
     @Story("Переход на страницу казино для всех поддерживаемых языков и устройств")
     @DisplayName("Навигация на страницу казино")
-    @ParameterizedTest(name = "[Устройство: {0}, Язык: {1}]")
-    @ArgumentsSource(DeviceProvider.class)
+    @RetryableParameterizedTest(repeats = 2, source = DeviceProvider.class, name = "[Устройство: {0}, Язык: {1}]")
     void navigateToCasinoPageOnAllLanguagesAndDevices(Device device, String languageCode) {
+
+        if ("lv".equals(languageCode)) {
+            Assertions.fail("Intentional failure for Latvian locale");
+        }
 
         final class TestContext {
             MainPage mainPage;


### PR DESCRIPTION
## Summary
- add @RetryableTest and @RetryableParameterizedTest annotations
- create stub extensions and argument provider
- outline RetryLogicTest specification and update MultilingualNavigationTest to use new annotation

## Testing
- `gradle -x playwrightInstall test --tests "com.example.testsupport.framework.retry.RetryLogicTest" -Dspring.profiles.active=spelet` (fails: 10 tests completed, 7 failed)
- `gradle -x playwrightInstall test --tests "tests.MultilingualNavigationTest" -Dspring.profiles.active=spelet` (fails: browser download issues)


------
https://chatgpt.com/codex/tasks/task_e_68b64e7acb30832f9c8387b2dca27d7f