### PR TITLE
feat: introduce retry annotation stubs and diagnostic tests

### DIFF
--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
@@ -1,0 +1,24 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableParameterizedTestExtension.class)
+public @interface RetryableParameterizedTest {
+    int repeats() default 1;
+    int minSuccess() default 1;
+    long suspend() default 0L;
+    Class<? extends Throwable>[] exceptions() default {Throwable.class};
+    String name() default "[{index}] {arguments}";
+    String repeatedName() default "{displayName} (retry {currentRepetition}/{totalRepetitions})";
+    Class<? extends ArgumentsProvider> source();
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
@@ -1,0 +1,81 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+public class RetryableParameterizedTestExtension implements TestTemplateInvocationContextProvider {
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return true;
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        Method testMethod = context.getRequiredTestMethod();
+        RetryableParameterizedTest annotation = testMethod.getAnnotation(RetryableParameterizedTest.class);
+        Class<? extends ArgumentsProvider> providerClass = annotation.source();
+        ArgumentsProvider provider;
+        try {
+            provider = providerClass.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new ExtensionConfigurationException("Failed to instantiate ArgumentsProvider", e);
+        }
+        Stream<? extends Arguments> arguments;
+        try {
+            arguments = provider.provideArguments(context);
+        } catch (Exception e) {
+            throw new ExtensionConfigurationException("Failed to provide arguments", e);
+        }
+        AtomicInteger index = new AtomicInteger(0);
+        return arguments.map(args -> new SimpleInvocationContext(args, annotation.name(), index.getAndIncrement()));
+    }
+
+    private static class SimpleInvocationContext implements TestTemplateInvocationContext {
+        private final Arguments arguments;
+        private final String namePattern;
+        private final int index;
+
+        SimpleInvocationContext(Arguments arguments, String namePattern, int index) {
+            this.arguments = arguments;
+            this.namePattern = namePattern;
+            this.index = index;
+        }
+
+        @Override
+        public String getDisplayName(int invocationIndex) {
+            String argsString = Arrays.toString(arguments.get());
+            return namePattern
+                    .replace("{index}", String.valueOf(index))
+                    .replace("{arguments}", argsString);
+        }
+
+        @Override
+        public List<Extension> getAdditionalExtensions() {
+            return List.of(new ParameterResolver() {
+                @Override
+                public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                    return true;
+                }
+
+                @Override
+                public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                    return arguments.get()[parameterContext.getIndex()];
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
@@ -1,0 +1,20 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableTestExtension.class)
+public @interface RetryableTest {
+    int repeats() default 1;
+    int minSuccess() default 1;
+    long suspend() default 0L;
+    Class<? extends Throwable>[] exceptions() default {Throwable.class};
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
@@ -1,0 +1,19 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+import java.util.stream.Stream;
+
+public class RetryableTestExtension implements TestTemplateInvocationContextProvider {
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return true;
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        return Stream.of(new TestTemplateInvocationContext() {});
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
+++ b/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
@@ -1,0 +1,19 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.stream.Stream;
+
+public class FlakyTestArgumentProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return Stream.of(
+                Arguments.of("Успех с 1-й попытки", 0),
+                Arguments.of("Успех после 1 падения", 1),
+                Arguments.of("Успех после 2 падений", 2),
+                Arguments.of("Всегда падает", -1)
+        );
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
+++ b/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
@@ -1,0 +1,73 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Execution(ExecutionMode.CONCURRENT)
+class RetryLogicTest {
+
+    private static final Map<String, AtomicInteger> attemptCounters = new ConcurrentHashMap<>();
+
+    @BeforeEach
+    void setUp() {
+        attemptCounters.clear();
+    }
+
+    @RetryableTest(repeats = 1)
+    @Test
+    void whenTestIsFlaky_itShouldSucceedOnRetry() {
+        AtomicInteger counter = attemptCounters.computeIfAbsent("flaky", k -> new AtomicInteger());
+        int attempt = counter.incrementAndGet();
+        if (attempt < 2) {
+            Assertions.fail("Flaky failure");
+        }
+        Assertions.assertEquals(2, counter.get());
+    }
+
+    @RetryableTest(repeats = 2)
+    @Test
+    void whenTestAlwaysFails_itShouldThrowAfterAllAttempts() {
+        AtomicInteger counter = attemptCounters.computeIfAbsent("alwaysFail", k -> new AtomicInteger());
+        Assertions.assertThrows(AssertionError.class, () -> {
+            counter.incrementAndGet();
+            Assertions.fail("Always fail");
+        });
+        Assertions.assertEquals(3, counter.get());
+    }
+
+    @RetryableParameterizedTest(repeats = 3, source = FlakyTestArgumentProvider.class)
+    void whenParameterizedIsFlaky_itShouldSucceedOnRetry(String scenario, int failures) {
+        AtomicInteger counter = attemptCounters.computeIfAbsent(scenario, k -> new AtomicInteger());
+        if (failures == -1) {
+            Assertions.assertThrows(AssertionError.class, () -> {
+                counter.incrementAndGet();
+                Assertions.fail("Always fails");
+            });
+            Assertions.assertEquals(4, counter.get());
+            return;
+        }
+        int attempt = counter.incrementAndGet();
+        if (attempt <= failures) {
+            Assertions.fail("Flaky failure");
+        }
+        Assertions.assertEquals(failures + 1, counter.get());
+    }
+
+    @RetryableTest(repeats = 5, exceptions = {java.io.IOException.class})
+    @Test
+    void whenExceptionTypeDoesNotMatch_itShouldFailWithoutRetry() {
+        AtomicInteger counter = attemptCounters.computeIfAbsent("exceptionFilter", k -> new AtomicInteger());
+        Assertions.assertThrows(AssertionError.class, () -> {
+            counter.incrementAndGet();
+            Assertions.fail("Non-IO failure");
+        });
+        Assertions.assertEquals(1, counter.get());
+    }
+}


### PR DESCRIPTION
## Summary
- add `@RetryableTest` and `@RetryableParameterizedTest` annotations
- scaffold stub extensions for retryable tests and parameterized tests
- provide diagnostic `RetryLogicTest` with flaky scenarios for future TDD

## Testing
- `gradle test --tests "com.example.testsupport.framework.retry.RetryLogicTest" -Dspring.profiles.active=spelet -x playwrightInstall` *(fails: 10 tests completed, 6 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6514e1e9c832f8f206989b64da1d2