### PR TITLE
feat: add retryable test annotations and placeholder extension

### DIFF
--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
@@ -1,0 +1,23 @@
+package com.example.testsupport.framework.retry;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableParameterizedTestExtension.class)
+public @interface RetryableParameterizedTest {
+    int repeats() default 1;
+    int minSuccess() default 1;
+    long suspend() default 0L;
+    Class<? extends Throwable>[] exceptions() default {Throwable.class};
+    String name() default "[{index}] {arguments}";
+    String repeatedName() default "{displayName} (retry {currentRepetition}/{totalRepetitions})";
+    Class<? extends ArgumentsProvider> source();
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
@@ -1,0 +1,69 @@
+package com.example.testsupport.framework.retry;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+public class RetryableParameterizedTestExtension implements TestTemplateInvocationContextProvider {
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return context.getTestMethod().map(m -> m.isAnnotationPresent(RetryableParameterizedTest.class)).orElse(false);
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        RetryableParameterizedTest annotation = context.getRequiredTestMethod().getAnnotation(RetryableParameterizedTest.class);
+        ArgumentsProvider provider;
+        try {
+            provider = annotation.source().getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new RuntimeException("Failed to instantiate ArgumentsProvider", e);
+        }
+        Stream<? extends Arguments> arguments;
+        try {
+            arguments = provider.provideArguments(context);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to provide arguments", e);
+        }
+        return arguments.map(ParameterizedInvocationContext::new);
+    }
+
+    private static class ParameterizedInvocationContext implements TestTemplateInvocationContext {
+        private final Arguments arguments;
+
+        ParameterizedInvocationContext(Arguments arguments) {
+            this.arguments = arguments;
+        }
+
+        @Override
+        public String getDisplayName(int invocationIndex) {
+            return String.format("[%d]", invocationIndex);
+        }
+
+        @Override
+        public List<Extension> getAdditionalExtensions() {
+            return Collections.singletonList(new ParameterResolver() {
+                @Override
+                public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                    Object[] args = arguments.get();
+                    return parameterContext.getIndex() < args.length;
+                }
+
+                @Override
+                public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                    return arguments.get()[parameterContext.getIndex()];
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
@@ -1,0 +1,19 @@
+package com.example.testsupport.framework.retry;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableTestExtension.class)
+public @interface RetryableTest {
+    int repeats() default 1;
+    int minSuccess() default 1;
+    long suspend() default 0L;
+    Class<? extends Throwable>[] exceptions() default {Throwable.class};
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
@@ -1,0 +1,24 @@
+package com.example.testsupport.framework.retry;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+public class RetryableTestExtension implements TestTemplateInvocationContextProvider {
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return context.getTestMethod().map(m -> m.isAnnotationPresent(RetryableTest.class)).orElse(false);
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        return Stream.of(new TestTemplateInvocationContext() {
+            @Override
+            public String getDisplayName(int invocationIndex) {
+                return context.getDisplayName();
+            }
+        });
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
+++ b/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
@@ -1,0 +1,19 @@
+package com.example.testsupport.framework.retry;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+public class FlakyTestArgumentProvider implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return Stream.of(
+                Arguments.of("Успех с 1-й попытки", 0),
+                Arguments.of("Успех после 1 падения", 1),
+                Arguments.of("Успех после 2 падений", 2),
+                Arguments.of("Всегда падает", -1)
+        );
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
+++ b/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
@@ -1,0 +1,71 @@
+package com.example.testsupport.framework.retry;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+class RetryLogicTest {
+
+    private static final Map<String, AtomicInteger> attemptCounters = new ConcurrentHashMap<>();
+
+    @BeforeEach
+    void reset() {
+        attemptCounters.clear();
+    }
+
+    @Test
+    @RetryableTest(repeats = 1)
+    void whenTestIsFlaky_itShouldSucceedOnRetry() {
+        AtomicInteger counter = attemptCounters.computeIfAbsent("flaky", k -> new AtomicInteger());
+        int attempt = counter.incrementAndGet();
+        if (attempt < 2) {
+            Assertions.fail("Flaky failure");
+        }
+        Assertions.assertEquals(2, counter.get());
+    }
+
+    @Test
+    @RetryableTest(repeats = 2)
+    void whenTestAlwaysFails_itShouldThrowAfterAllAttempts() {
+        AtomicInteger counter = attemptCounters.computeIfAbsent("alwaysFail", k -> new AtomicInteger());
+        Assertions.assertThrows(AssertionError.class, () -> {
+            counter.incrementAndGet();
+            Assertions.fail("Always failing");
+        });
+        Assertions.assertEquals(3, counter.get());
+    }
+
+    @RetryableParameterizedTest(repeats = 3, source = FlakyTestArgumentProvider.class)
+    void whenParameterizedIsFlaky_itShouldSucceedOnRetry(String scenario, int failures) {
+        AtomicInteger counter = attemptCounters.computeIfAbsent(scenario, k -> new AtomicInteger());
+        if (failures == -1) {
+            Assertions.assertThrows(AssertionError.class, () -> {
+                counter.incrementAndGet();
+                Assertions.fail("Always failing");
+            });
+            Assertions.assertEquals(4, counter.get());
+            return;
+        }
+        int attempt = counter.incrementAndGet();
+        if (attempt <= failures) {
+            Assertions.fail("Flaky failure");
+        }
+        Assertions.assertEquals(failures + 1, counter.get());
+    }
+
+    @Test
+    @RetryableTest(repeats = 5, exceptions = {IOException.class})
+    void whenExceptionTypeDoesNotMatch_itShouldFailWithoutRetry() {
+        AtomicInteger counter = attemptCounters.computeIfAbsent("exceptionType", k -> new AtomicInteger());
+        Assertions.assertThrows(AssertionError.class, () -> {
+            counter.incrementAndGet();
+            Assertions.fail("Failure");
+        });
+        Assertions.assertEquals(1, counter.get());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `@RetryableTest` and `@RetryableParameterizedTest` annotations
- add placeholder retry extensions and argument provider
- add `RetryLogicTest` specification tests (currently failing)

## Testing
- `gradle test --tests "com.example.testsupport.framework.retry.RetryLogicTest" -Dspring.profiles.active=spelet -x playwrightInstall` *(fails: 10 tests completed, 6 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6514e1e9c832f8f206989b64da1d2