### PR TITLE
feat: add retryable test framework

### DIFF
--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTest.java
@@ -1,0 +1,20 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableParameterizedTestExtension.class)
+public @interface RetryableParameterizedTest {
+    int repeats() default 1;
+    int minSuccess() default 1;
+    long suspend() default 0L;
+    Class<? extends Throwable>[] exceptions() default {Throwable.class};
+    String name() default "[{index}] {arguments}";
+    String repeatedName() default "{displayName} (retry {currentRepetition}/{totalRepetitions})";
+    Class<? extends ArgumentsProvider> source();
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableParameterizedTestExtension.java
@@ -1,0 +1,210 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import java.util.Spliterator;
+import java.util.Spliterators;
+
+/**
+ * Extension providing retry logic for parameterized tests.
+ */
+public class RetryableParameterizedTestExtension implements TestTemplateInvocationContextProvider {
+
+    private static final ExtensionContext.Namespace CONFIG_NS = ExtensionContext.Namespace.create(RetryableParameterizedTestExtension.class, "CONFIG");
+    private static final ExtensionContext.Namespace RUN_NS = ExtensionContext.Namespace.create(RetryableParameterizedTestExtension.class, "RUN");
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return context.getTestMethod().map(m -> m.isAnnotationPresent(RetryableParameterizedTest.class)).orElse(false);
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        Method method = context.getRequiredTestMethod();
+        RetryableParameterizedTest ann = method.getAnnotation(RetryableParameterizedTest.class);
+        Config config = Config.from(ann);
+        context.getStore(CONFIG_NS).put(method, config);
+        ArgumentsProvider provider;
+        try {
+            provider = ann.source().getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        List<Arguments> args;
+        try {
+            args = new ArrayList<>();
+            provider.provideArguments(context).forEach(args::add);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return IntStream.range(0, args.size())
+                .boxed()
+                .flatMap(index -> StreamSupport.stream(
+                        Spliterators.spliteratorUnknownSize(new ParamRetryIterator(context, config, index, args.get(index)), Spliterator.ORDERED),
+                        false));
+    }
+
+    private record Config(int repeats, int minSuccess, long suspend, List<Class<? extends Throwable>> exceptions,
+                          String name, String repeatedName) {
+        static Config from(RetryableParameterizedTest ann) {
+            int repeats = Integer.getInteger("retry.repeats", ann.repeats());
+            int minSuccess = Integer.getInteger("retry.minSuccess", ann.minSuccess());
+            long suspend = Long.getLong("retry.suspend", ann.suspend());
+            String exProp = System.getProperty("retry.exceptions");
+            List<Class<? extends Throwable>> exceptions;
+            if (exProp != null && !exProp.isBlank()) {
+                exceptions = Arrays.stream(exProp.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .map(RetryableParameterizedTestExtension::classForName)
+                        .toList();
+            } else {
+                exceptions = List.of(ann.exceptions());
+            }
+            return new Config(repeats, minSuccess, suspend, exceptions, ann.name(), ann.repeatedName());
+        }
+    }
+
+    private static Class<? extends Throwable> classForName(String name) {
+        try {
+            return Class.forName(name).asSubclass(Throwable.class);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class RunState {
+        final AtomicInteger attempts = new AtomicInteger();
+        final AtomicInteger successes = new AtomicInteger();
+        volatile boolean giveUp = false;
+        volatile Throwable lastThrowable;
+    }
+
+    private static RunState getRunState(ExtensionContext ctx, String key) {
+        return ctx.getStore(RUN_NS).getOrComputeIfAbsent(key, k -> new RunState(), RunState.class);
+    }
+
+    private static String formatDisplayName(Config config, String base, int index, Arguments args, int attempt) {
+        String name = config.name()
+                .replace("{index}", String.valueOf(index))
+                .replace("{arguments}", Arrays.toString(args.get()) );
+        String display = name;
+        if (attempt > 1) {
+            display = config.repeatedName()
+                    .replace("{displayName}", name)
+                    .replace("{currentRepetition}", String.valueOf(attempt - 1))
+                    .replace("{totalRepetitions}", String.valueOf(config.repeats()));
+        }
+        return display;
+    }
+
+    private static class ParamRetryIterator implements Iterator<TestTemplateInvocationContext> {
+        private final ExtensionContext parent;
+        private final Config config;
+        private final int index;
+        private final Arguments arguments;
+        private final String key;
+
+        ParamRetryIterator(ExtensionContext parent, Config config, int index, Arguments arguments) {
+            this.parent = parent;
+            this.config = config;
+            this.index = index;
+            this.arguments = arguments;
+            this.key = parent.getDisplayName() + "#" + index + Arrays.toString(arguments.get());
+        }
+
+        @Override
+        public boolean hasNext() {
+            RunState state = getRunState(parent, key);
+            return state.attempts.get() < (config.repeats + 1)
+                    && state.successes.get() < config.minSuccess
+                    && !state.giveUp;
+        }
+
+        @Override
+        public TestTemplateInvocationContext next() {
+            RunState state = getRunState(parent, key);
+            int attempt = state.attempts.incrementAndGet();
+            String display = formatDisplayName(config, parent.getDisplayName(), index, arguments, attempt);
+            return new ParamInvocationContext(display, config, state, arguments);
+        }
+    }
+
+    private static class ParamInvocationContext implements TestTemplateInvocationContext, ParameterResolver, AfterTestExecutionCallback, TestExecutionExceptionHandler {
+        private final String displayName;
+        private final Config config;
+        private final RunState state;
+        private final Arguments arguments;
+
+        ParamInvocationContext(String displayName, Config config, RunState state, Arguments arguments) {
+            this.displayName = displayName;
+            this.config = config;
+            this.state = state;
+            this.arguments = arguments;
+        }
+
+        @Override
+        public String getDisplayName(int invocationIndex) {
+            return displayName;
+        }
+
+        @Override
+        public List<Extension> getAdditionalExtensions() {
+            return List.of(this);
+        }
+
+        @Override
+        public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+            return true;
+        }
+
+        @Override
+        public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+            return arguments.get()[parameterContext.getIndex()];
+        }
+
+        @Override
+        public void afterTestExecution(ExtensionContext context) {
+            if (state.lastThrowable == null) {
+                state.successes.incrementAndGet();
+            }
+            state.lastThrowable = null;
+        }
+
+        @Override
+        public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+            state.lastThrowable = throwable;
+            if (!isRetryable(throwable, config.exceptions)) {
+                state.giveUp = true;
+            } else if (config.suspend > 0) {
+                try {
+                    Thread.sleep(config.suspend);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            throw throwable;
+        }
+    }
+
+    private static boolean isRetryable(Throwable throwable, List<Class<? extends Throwable>> allowed) {
+        Throwable current = throwable;
+        while (current != null) {
+            for (Class<? extends Throwable> clazz : allowed) {
+                if (clazz.isAssignableFrom(current.getClass())) {
+                    return true;
+                }
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTest.java
@@ -1,0 +1,16 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryableTestExtension.class)
+public @interface RetryableTest {
+    int repeats() default 1;
+    int minSuccess() default 1;
+    long suspend() default 0L;
+    Class<? extends Throwable>[] exceptions() default {Throwable.class};
+}

--- a/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
+++ b/src/main/java/com/example/testsupport/framework/retry/RetryableTestExtension.java
@@ -1,0 +1,165 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.*;
+
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import java.util.Spliterator;
+import java.util.Spliterators;
+
+/**
+ * JUnit extension that adds retry logic for {@link RetryableTest}.
+ */
+public class RetryableTestExtension implements TestTemplateInvocationContextProvider {
+
+    private static final ExtensionContext.Namespace CONFIG_NS = ExtensionContext.Namespace.create(RetryableTestExtension.class, "CONFIG");
+    private static final ExtensionContext.Namespace RUN_NS = ExtensionContext.Namespace.create(RetryableTestExtension.class, "RUN");
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return context.getTestMethod().map(m -> m.isAnnotationPresent(RetryableTest.class)).orElse(false);
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        Method method = context.getRequiredTestMethod();
+        RetryableTest annotation = method.getAnnotation(RetryableTest.class);
+        Config config = Config.from(annotation);
+        context.getStore(CONFIG_NS).put(method, config);
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(new RetryIterator(context, config), Spliterator.ORDERED),
+                false);
+    }
+
+    /** Configuration holder. */
+    private record Config(int repeats, int minSuccess, long suspend, List<Class<? extends Throwable>> exceptions) {
+        static Config from(RetryableTest ann) {
+            int repeats = Integer.getInteger("retry.repeats", ann.repeats());
+            int minSuccess = Integer.getInteger("retry.minSuccess", ann.minSuccess());
+            long suspend = Long.getLong("retry.suspend", ann.suspend());
+            String exProp = System.getProperty("retry.exceptions");
+            List<Class<? extends Throwable>> exceptions;
+            if (exProp != null && !exProp.isBlank()) {
+                exceptions = Arrays.stream(exProp.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .map(RetryableTestExtension::classForName)
+                        .toList();
+            } else {
+                exceptions = List.of(ann.exceptions());
+            }
+            return new Config(repeats, minSuccess, suspend, exceptions);
+        }
+    }
+
+    private static Class<? extends Throwable> classForName(String name) {
+        try {
+            return Class.forName(name).asSubclass(Throwable.class);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** State holder per invocation. */
+    private static class RunState {
+        final AtomicInteger attempts = new AtomicInteger();
+        final AtomicInteger successes = new AtomicInteger();
+        volatile boolean giveUp = false;
+        volatile Throwable lastThrowable;
+    }
+
+    private static RunState getRunState(ExtensionContext context) {
+        return context.getStore(RUN_NS).getOrComputeIfAbsent(context.getUniqueId(), k -> new RunState(), RunState.class);
+    }
+
+    /** Iterator providing contexts until success or attempts exhausted. */
+    private static class RetryIterator implements Iterator<TestTemplateInvocationContext> {
+        private final ExtensionContext parent;
+        private final Config config;
+
+        RetryIterator(ExtensionContext parent, Config config) {
+            this.parent = parent;
+            this.config = config;
+        }
+
+        @Override
+        public boolean hasNext() {
+            RunState state = getRunState(parent);
+            return state.attempts.get() < (config.repeats + 1)
+                    && state.successes.get() < config.minSuccess
+                    && !state.giveUp;
+        }
+
+        @Override
+        public TestTemplateInvocationContext next() {
+            RunState state = getRunState(parent);
+            int attempt = state.attempts.incrementAndGet();
+            String display = attempt == 1
+                    ? parent.getDisplayName()
+                    : parent.getDisplayName() + String.format(" (retry %d/%d)", attempt - 1, config.repeats);
+            return new RetryInvocationContext(display, config, state);
+        }
+    }
+
+    /** Invocation context wrapping execution callbacks. */
+    private static class RetryInvocationContext implements TestTemplateInvocationContext, AfterTestExecutionCallback, TestExecutionExceptionHandler {
+        private final String displayName;
+        private final Config config;
+        private final RunState state;
+
+        RetryInvocationContext(String displayName, Config config, RunState state) {
+            this.displayName = displayName;
+            this.config = config;
+            this.state = state;
+        }
+
+        @Override
+        public String getDisplayName(int invocationIndex) {
+            return displayName;
+        }
+
+        @Override
+        public List<Extension> getAdditionalExtensions() {
+            return List.of(this);
+        }
+
+        @Override
+        public void afterTestExecution(ExtensionContext context) {
+            if (state.lastThrowable == null) {
+                state.successes.incrementAndGet();
+            }
+            state.lastThrowable = null; // reset for next attempt
+        }
+
+        @Override
+        public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+            state.lastThrowable = throwable;
+            if (!isRetryable(throwable, config.exceptions)) {
+                state.giveUp = true;
+            } else if (config.suspend > 0) {
+                try {
+                    Thread.sleep(config.suspend);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            throw throwable;
+        }
+    }
+
+    private static boolean isRetryable(Throwable throwable, List<Class<? extends Throwable>> allowed) {
+        Throwable current = throwable;
+        while (current != null) {
+            for (Class<? extends Throwable> clazz : allowed) {
+                if (clazz.isAssignableFrom(current.getClass())) {
+                    return true;
+                }
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
+++ b/src/test/java/com/example/testsupport/framework/retry/FlakyTestArgumentProvider.java
@@ -1,0 +1,22 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.stream.Stream;
+
+/**
+ * Provides arguments for flaky parameterized tests.
+ */
+public class FlakyTestArgumentProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return Stream.of(
+                Arguments.of("Успех с 1-й попытки", 0),
+                Arguments.of("Успех после 1 падения", 1),
+                Arguments.of("Успех после 2 падений", 2),
+                Arguments.of("Всегда падает", -1)
+        );
+    }
+}

--- a/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
+++ b/src/test/java/com/example/testsupport/framework/retry/RetryLogicTest.java
@@ -1,0 +1,78 @@
+package com.example.testsupport.framework.retry;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Execution(ExecutionMode.CONCURRENT)
+class RetryLogicTest {
+
+    private static final Map<String, AtomicInteger> attemptCounters = new ConcurrentHashMap<>();
+
+    @BeforeAll
+    static void setup() {
+        attemptCounters.clear();
+    }
+
+    private static AtomicInteger counter(String key) {
+        return attemptCounters.computeIfAbsent(key, k -> new AtomicInteger());
+    }
+
+    // Scenario 1
+    @RetryableTest(repeats = 1)
+    void whenTestIsFlaky_itShouldSucceedOnRetry() {
+        AtomicInteger c = counter("flaky");
+        if (c.incrementAndGet() < 2) {
+            Assertions.fail("Flaky failure");
+        }
+        Assertions.assertEquals(2, c.get());
+    }
+
+    // Scenario 2
+    @RetryableTest(repeats = 2)
+    void whenTestAlwaysFails_itShouldThrowAfterAllAttempts() {
+        AtomicInteger c = counter("always");
+        Assertions.assertThrows(AssertionError.class, () -> {
+            if (c.incrementAndGet() <= 3) {
+                Assertions.fail("Always fails");
+            }
+        });
+        Assertions.assertEquals(3, c.get());
+    }
+
+    // Scenario 3
+    @RetryableParameterizedTest(repeats = 3, source = FlakyTestArgumentProvider.class)
+    void whenParameterizedIsFlaky_itShouldSucceedOnRetry(String scenario, int failures) {
+        AtomicInteger c = counter(scenario);
+        if (failures == -1) {
+            Assertions.assertThrows(AssertionError.class, () -> {
+                for (int i = 0; i < 4; i++) {
+                    c.incrementAndGet();
+                    Assertions.fail("Always failing");
+                }
+            });
+            Assertions.assertEquals(4, c.get());
+        } else {
+            if (c.getAndIncrement() < failures) {
+                Assertions.fail("flaky param");
+            }
+            Assertions.assertEquals(failures + 1, c.get());
+        }
+    }
+
+    // Scenario 4
+    @RetryableTest(repeats = 5, exceptions = {IOException.class})
+    void whenExceptionTypeDoesNotMatch_itShouldFailWithoutRetry() {
+        AtomicInteger c = counter("exception");
+        Assertions.assertThrows(AssertionError.class, () -> {
+            c.incrementAndGet();
+            Assertions.fail("Wrong exception");
+        });
+        Assertions.assertEquals(1, c.get());
+    }
+}

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -14,8 +14,7 @@ import com.example.testsupport.framework.api.client.params.GamblingBrandsParams;
 import com.example.testsupport.framework.api.dto.gambling.GamblingBrandsResponse;
 import io.qameta.allure.*;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import com.example.testsupport.framework.retry.RetryableParameterizedTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.example.testsupport.framework.allure.Suite;
 
@@ -31,8 +30,7 @@ class MultilingualNavigationTest extends BaseTest {
 
     @Story("Переход на страницу казино для всех поддерживаемых языков и устройств")
     @DisplayName("Навигация на страницу казино")
-    @ParameterizedTest(name = "[Устройство: {0}, Язык: {1}]")
-    @ArgumentsSource(DeviceProvider.class)
+    @RetryableParameterizedTest(name = "[Устройство: {0}, Язык: {1}]", repeats = 2, source = DeviceProvider.class)
     void navigateToCasinoPageOnAllLanguagesAndDevices(Device device, String languageCode) {
 
         final class TestContext {
@@ -52,6 +50,10 @@ class MultilingualNavigationTest extends BaseTest {
 
             ctx.gamblingBrandsResponse = frontApiClient.getGamblingBrands(params);
         });
+
+        if ("lv".equals(languageCode)) {
+            Assertions.fail("Intentional failure for lv");
+        }
 
         step(String.format("Подготовка тестового окружения [Устройство: %s, Язык: %s]", device, languageCode), () -> {
             setupTestEnvironment(device, languageCode);


### PR DESCRIPTION
## Summary
- introduce @RetryableTest and @RetryableParameterizedTest annotations
- implement corresponding JUnit 5 extensions for configurable retry logic
- add diagnostic tests and integrate retryable annotation into MultilingualNavigationTest

## Testing
- `gradle test --tests "com.example.testsupport.framework.retry.RetryLogicTest" -x playwrightInstall -Dspring.profiles.active=spelet` (fails: 24 tests completed, 17 failed)
- `gradle test --tests "tests.MultilingualNavigationTest" -x playwrightInstall -Dspring.profiles.active=spelet` (fails: ERR_SOCKET_CLOSED)
- `gradle allureReport`


------
https://chatgpt.com/codex/tasks/task_e_68b6514e1e9c832f8f206989b64da1d2