### PR TITLE
Randomize casino provider in navigation test

### DIFF
--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -12,6 +12,7 @@ import com.example.testsupport.pages.components.AuthModalComponent;
 import com.example.testsupport.framework.api.client.FrontApiClient;
 import com.example.testsupport.framework.api.client.params.GamblingBrandsParams;
 import com.example.testsupport.framework.api.dto.gambling.GamblingBrandsResponse;
+import java.util.concurrent.ThreadLocalRandom;
 import io.qameta.allure.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -71,8 +72,10 @@ class MultilingualNavigationTest extends BaseTest {
                     .verifyIsLoaded();
         });
 
-        step("Выбираем провайдера 'Play'n Go'", () -> {
-            ctx.filterDrawer.selectProvider("Play'n Go");
+        step("Выбираем случайного провайдера", () -> {
+            var brands = ctx.gamblingBrandsResponse.brands();
+            var randomBrandName = brands.get(ThreadLocalRandom.current().nextInt(brands.size())).name();
+            ctx.filterDrawer.selectProvider(randomBrandName);
         });
 
         step("Применяем фильтры", () -> {


### PR DESCRIPTION
## Summary
- choose a random provider from API brand list in MultilingualNavigationTest

## Testing
- `gradle test --tests tests.MultilingualNavigationTest` *(fails: Failed to download Chromium)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ca2abf8c832fba35aef419816285