### PR TITLE
Compare casino categories from API and UI

### DIFF
--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -11,6 +11,7 @@ import com.example.testsupport.pages.components.CookieBannerComponent;
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.AriaRole;
+import java.util.List;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
@@ -120,6 +121,18 @@ public class CasinoPage extends BasePage<CasinoPage> {
             }
             button.click();
             return filterDrawerComponentProvider.getObject();
+        });
+    }
+
+    /**
+     * Returns a list of horizontal category titles displayed on the page.
+     *
+     * @return list of category titles in display order
+     */
+    public List<String> getCategoryTitles() {
+        return step("Получение списка горизонтальных категорий", () -> {
+            Locator categories = page.locator("div[role='tablist'][aria-orientation='horizontal'] [role='tab']");
+            return categories.allTextContents();
         });
     }
 

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -15,12 +15,14 @@ import com.example.testsupport.framework.api.client.params.DeviceType;
 import com.example.testsupport.framework.api.dto.gambling.GamblingBrandsResponse;
 import com.example.testsupport.framework.api.dto.gambling.GamblingCategoriesResponse;
 import com.example.testsupport.framework.api.dto.gambling.GamblingGamesResponse;
+import com.example.testsupport.framework.api.dto.gambling.GameCategory;
 import io.qameta.allure.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.example.testsupport.framework.allure.Suite;
+import java.util.List;
 
 import static com.example.testsupport.framework.utils.AllureHelper.step;
 
@@ -90,6 +92,14 @@ class MultilingualNavigationTest extends BaseTest {
 
         step("Переходим на страницу 'Казино'", () -> {
             ctx.casinoPage = ctx.mainPage.navigateToCasino();
+        });
+
+        step("Сравниваем категории из API и интерфейса", () -> {
+            List<String> apiCategories = ctx.gamblingCategoriesResponse.gameCategories().stream()
+                    .map(GameCategory::name)
+                    .toList();
+            List<String> uiCategories = ctx.casinoPage.getCategoryTitles();
+            Assertions.assertIterableEquals(apiCategories, uiCategories);
         });
     }
 }


### PR DESCRIPTION
## Summary
- expose category titles on casino page
- verify casino categories match API list

## Testing
- `gradle test --console=plain` *(fails: Failed to download Chromium 130.0.6723.31)*

------
https://chatgpt.com/codex/tasks/task_e_68be0a446e24832fa35e0ea32ae8a697