### PR TITLE
Compare casino brand list with API

### DIFF
--- a/src/test/java/com/example/testsupport/framework/api/dto/gambling/GamblingBrandsResponse.java
+++ b/src/test/java/com/example/testsupport/framework/api/dto/gambling/GamblingBrandsResponse.java
@@ -2,5 +2,12 @@ package com.example.testsupport.framework.api.dto.gambling;
 
 import java.util.List;
 
-public record GamblingBrandsResponse(List<Brand> brands) {}
+public record GamblingBrandsResponse(List<Brand> brands) {
+
+    public List<String> brandNames() {
+        return brands.stream()
+                .map(Brand::name)
+                .toList();
+    }
+}
 

--- a/src/test/java/com/example/testsupport/framework/api/dto/gambling/GamblingCategoriesResponse.java
+++ b/src/test/java/com/example/testsupport/framework/api/dto/gambling/GamblingCategoriesResponse.java
@@ -46,5 +46,17 @@ public record GamblingCategoriesResponse(List<GameCategory> gameCategories) {
                 .map(GameCategory::name)
                 .toList();
     }
+
+    /**
+     * Returns the titles of vertical categories.
+     *
+     * @return list of vertical category titles
+     */
+    public List<String> verticalCategoryNames() {
+        return gameCategories.stream()
+                .filter(gc -> gc.type() == GameCategoryType.VERTICAL)
+                .map(GameCategory::name)
+                .toList();
+    }
 }
 

--- a/src/test/java/com/example/testsupport/framework/api/dto/gambling/GamblingCategoriesResponse.java
+++ b/src/test/java/com/example/testsupport/framework/api/dto/gambling/GamblingCategoriesResponse.java
@@ -26,18 +26,6 @@ public record GamblingCategoriesResponse(List<GameCategory> gameCategories) {
     }
 
     /**
-     * Returns only the titles of horizontal categories without the lobby item.
-     *
-     * @return list of horizontal category titles
-     */
-    public List<String> horizontalCategoryNames() {
-        return gameCategories.stream()
-                .filter(gc -> gc.type() == GameCategoryType.HORIZONTAL)
-                .map(GameCategory::name)
-                .toList();
-    }
-
-    /**
      * Returns the titles of navigation panel categories.
      *
      * @return list of navigation panel category titles

--- a/src/test/java/com/example/testsupport/framework/api/dto/gambling/GamblingCategoriesResponse.java
+++ b/src/test/java/com/example/testsupport/framework/api/dto/gambling/GamblingCategoriesResponse.java
@@ -26,6 +26,18 @@ public record GamblingCategoriesResponse(List<GameCategory> gameCategories) {
     }
 
     /**
+     * Returns only the titles of horizontal categories without the lobby item.
+     *
+     * @return list of horizontal category titles
+     */
+    public List<String> horizontalCategoryNames() {
+        return gameCategories.stream()
+                .filter(gc -> gc.type() == GameCategoryType.HORIZONTAL)
+                .map(GameCategory::name)
+                .toList();
+    }
+
+    /**
      * Returns the titles of navigation panel categories.
      *
      * @return list of navigation panel category titles

--- a/src/test/java/com/example/testsupport/framework/api/dto/gambling/GamblingCategoriesResponse.java
+++ b/src/test/java/com/example/testsupport/framework/api/dto/gambling/GamblingCategoriesResponse.java
@@ -10,18 +10,28 @@ import java.util.stream.Stream;
 public record GamblingCategoriesResponse(List<GameCategory> gameCategories) {
 
     /**
+     * Returns the titles of horizontal categories without the lobby entry.
+     *
+     * @return list of horizontal category titles excluding lobby
+     */
+    public List<String> horizontalCategoryNames() {
+        return gameCategories.stream()
+                .filter(gc -> gc.type() == GameCategoryType.HORIZONTAL)
+                .map(GameCategory::name)
+                .toList();
+    }
+
+    /**
      * Returns the titles of horizontal categories prepended with the localized lobby title.
      *
      * @param ls localization service for resolving the lobby title
      * @return list of horizontal category titles including lobby
      */
-    public List<String> horizontalCategoryNames(LocalizationService ls) {
+    public List<String> horizontalCategoryNamesWithLobby(LocalizationService ls) {
         String lobby = ls.get("casino.navigation.lobby");
         return Stream.concat(
                 Stream.of(lobby),
-                gameCategories.stream()
-                        .filter(gc -> gc.type() == GameCategoryType.HORIZONTAL)
-                        .map(GameCategory::name)
+                horizontalCategoryNames().stream()
         ).toList();
     }
 

--- a/src/test/java/com/example/testsupport/pages/CasinoPage.java
+++ b/src/test/java/com/example/testsupport/pages/CasinoPage.java
@@ -76,7 +76,7 @@ public class CasinoPage extends BasePage<CasinoPage> {
      */
     @Override
     public CasinoPage verifyUrl() {
-        return step("Проверка URL страницы 'Казино'", () -> {
+        return step("[CasinoPage] Проверка URL страницы 'Казино'", () -> {
             verifyUrlContains(getExpectedPath());
             return this;
         });
@@ -86,7 +86,7 @@ public class CasinoPage extends BasePage<CasinoPage> {
      * Verifies that the lobby button is visible for the current viewport width.
      */
     public CasinoPage verifyLobbyButton() {
-        return step("Проверка кнопки 'Лобби'", () -> {
+        return step("[CasinoPage] Проверка кнопки 'Лобби'", () -> {
             Locator lobbyButton;
             int width = page.viewportSize() != null ? page.viewportSize().width : Integer.MAX_VALUE;
             if (width < Breakpoints.TABLET) {
@@ -106,7 +106,7 @@ public class CasinoPage extends BasePage<CasinoPage> {
      */
     @Override
     public CasinoPage verifyIsLoaded() {
-        return step("Проверка загрузки страницы 'Казино'", () -> {
+        return step("[CasinoPage] Проверка загрузки страницы 'Казино'", () -> {
             verifyLobbyButton();
             verifyUrl();
             return this;
@@ -119,7 +119,7 @@ public class CasinoPage extends BasePage<CasinoPage> {
      * @return filter drawer component
      */
     public FilterDrawerComponent openFilters() {
-        return step("Открытие панели фильтров", () -> {
+        return step("[CasinoPage] Открытие панели фильтров", () -> {
             Locator button;
             int width = page.viewportSize() != null ? page.viewportSize().width : Integer.MAX_VALUE;
             if (width < Breakpoints.TABLET) {
@@ -152,7 +152,7 @@ public class CasinoPage extends BasePage<CasinoPage> {
      * @return current page object
      */
     public CasinoPage typeInSearch(String query) {
-        return step(String.format("Вводим в поле поиска '%s'", query), () -> {
+        return step(String.format("[CasinoPage] Вводим в поле поиска '%s'", query), () -> {
             searchInput.fill(query);
             return this;
         });
@@ -165,7 +165,7 @@ public class CasinoPage extends BasePage<CasinoPage> {
      * @return current page object
      */
     public CasinoPage waitForGameVisible(String gameName) {
-        return step(String.format("Ожидаем отображения игры '%s'", gameName), () -> {
+        return step(String.format("[CasinoPage] Ожидаем отображения игры '%s'", gameName), () -> {
             Locator card = gameCards.filter(new Locator.FilterOptions().setHasText(gameName));
             assertThat(card.first()).isVisible();
             return this;
@@ -179,7 +179,7 @@ public class CasinoPage extends BasePage<CasinoPage> {
      * @return authorization modal component
      */
     public AuthModalComponent clickPlay(String gameName) {
-        return step(String.format("Запускаем игру '%s'", gameName), () -> {
+        return step(String.format("[CasinoPage] Запускаем игру '%s'", gameName), () -> {
             Locator card = gameCards.filter(new Locator.FilterOptions().setHasText(gameName)).first();
             card.getByRole(AriaRole.BUTTON).click();
             return authModalComponentProvider.getObject();

--- a/src/test/java/com/example/testsupport/pages/MainPage.java
+++ b/src/test/java/com/example/testsupport/pages/MainPage.java
@@ -33,7 +33,7 @@ public class MainPage extends BasePage<MainPage> {
 
     @Override
     public MainPage verifyUrl() {
-        return step("Проверка URL главной страницы", () -> {
+        return step("[MainPage] Проверка URL главной страницы", () -> {
             verifyUrlContains(getExpectedPath());
             return this;
         });
@@ -44,7 +44,7 @@ public class MainPage extends BasePage<MainPage> {
      */
     @SuppressWarnings("resource")
     public CasinoPage navigateToCasino() {
-        return step("Навигация на страницу 'Казино'", () -> {
+        return step("[MainPage] Навигация на страницу 'Казино'", () -> {
             int currentWidth = page.viewportSize().width;
             if (currentWidth < MOBILE) {
                 tabBar().clickCasino();
@@ -62,7 +62,7 @@ public class MainPage extends BasePage<MainPage> {
      */
     @Override
     public MainPage verifyIsLoaded() {
-        return step("Проверка загрузки главной страницы", () -> {
+        return step("[MainPage] Проверка загрузки главной страницы", () -> {
             header().verifyLogoVisible();
             verifyUrl();
             return this;
@@ -75,7 +75,7 @@ public class MainPage extends BasePage<MainPage> {
      * @return current page object
      */
     public MainPage open() {
-        return step("Открыть главную страницу", () -> {
+        return step("[MainPage] Открыть главную страницу", () -> {
             super.open();
             cookieBanner().acceptIfPresent();
             return verifyIsLoaded();

--- a/src/test/java/com/example/testsupport/pages/components/AuthModalComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/AuthModalComponent.java
@@ -32,7 +32,7 @@ public class AuthModalComponent extends BaseComponent {
      * @return current component instance
      */
     public AuthModalComponent verifyIsLoaded() {
-        return step("Проверяем отображение модального окна авторизации", () -> {
+        return step("[AuthModalComponent] Проверяем отображение модального окна авторизации", () -> {
             assertThat(title).isVisible();
             return this;
         });

--- a/src/test/java/com/example/testsupport/pages/components/CategoryTabsComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/CategoryTabsComponent.java
@@ -25,7 +25,7 @@ public class CategoryTabsComponent extends BaseComponent {
      * @return list of category titles in display order
      */
     public List<String> getTitles() {
-        return step("Получение списка горизонтальных категорий", () ->
+        return step("[CategoryTabsComponent] Получение списка горизонтальных категорий", () ->
             root().locator("[role='tab']").allInnerTexts()
         );
     }

--- a/src/test/java/com/example/testsupport/pages/components/CookieBannerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/CookieBannerComponent.java
@@ -31,7 +31,7 @@ public class CookieBannerComponent extends BaseComponent {
      * Clicks the localized "accept cookies" button, failing if it is not found within two seconds.
      */
     public void acceptIfPresent() {
-        step("Принять куки, если баннер отображается", () -> {
+        step("[CookieBannerComponent] Принять куки, если баннер отображается", () -> {
             String acceptText;
             try {
                 acceptText = ls.get("cookies.accept");

--- a/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
@@ -70,7 +70,8 @@ public class FilterDrawerComponent extends BaseComponent {
     public int getProviderCount() {
         return step("Получение значения счётчика брендов", () ->
                 Integer.parseInt(Objects.requireNonNull(
-                        root().locator("#brands-label .badge").textContent()).trim())
+                        root().locator("#brands-label").locator("..")
+                                .locator(".badge").textContent()).trim())
         );
     }
 

--- a/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
@@ -56,8 +56,8 @@ public class FilterDrawerComponent extends BaseComponent {
      */
     public List<String> getProviderNames() {
         return step("Получение списка провайдеров", () ->
-                root().getByRole(AriaRole.ROW).all().stream()
-                        .map(row -> Objects.requireNonNull(row.getAttribute("aria-label")))
+                root().locator(".provider-tag-group__tag").all().stream()
+                        .map(tag -> Objects.requireNonNull(tag.getAttribute("aria-label")))
                         .toList()
         );
     }

--- a/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
@@ -63,6 +63,19 @@ public class FilterDrawerComponent extends BaseComponent {
     }
 
     /**
+     * Returns the list of category names displayed in the drawer.
+     *
+     * @return list of category names
+     */
+    public List<String> getCategoryNames() {
+        return step("Получение списка категорий", () ->
+                root().locator("[aria-labelledby='categories-label']").locator(".tag-group__item").all().stream()
+                        .map(tag -> Objects.requireNonNull(tag.getAttribute("aria-label")))
+                        .toList()
+        );
+    }
+
+    /**
      * Selects a provider within the drawer by its visible name.
      *
      * @param providerName provider label as displayed in UI

--- a/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
@@ -63,6 +63,18 @@ public class FilterDrawerComponent extends BaseComponent {
     }
 
     /**
+     * Returns the value of the provider count badge.
+     *
+     * @return number of providers shown in the badge
+     */
+    public int getProviderCount() {
+        return step("Получение значения счётчика брендов", () ->
+                Integer.parseInt(Objects.requireNonNull(
+                        root().locator("#brands-label .badge").textContent()).trim())
+        );
+    }
+
+    /**
      * Returns the list of category names displayed in the drawer.
      *
      * @return list of category names

--- a/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
@@ -43,7 +43,7 @@ public class FilterDrawerComponent extends BaseComponent {
      * @return current component instance
      */
     public FilterDrawerComponent verifyIsLoaded() {
-        return step("Проверка загрузки дровера фильтров", () -> {
+        return step("[FilterDrawerComponent] Проверка загрузки дровера фильтров", () -> {
             assertThat(title).isVisible();
             return this;
         });
@@ -55,7 +55,7 @@ public class FilterDrawerComponent extends BaseComponent {
      * @return list of provider names
      */
     public List<String> getProviderNames() {
-        return step("Получение списка провайдеров", () ->
+        return step("[FilterDrawerComponent] Получение списка провайдеров", () ->
                 root().locator(".provider-tag-group__tag").all().stream()
                         .map(tag -> Objects.requireNonNull(tag.getAttribute("aria-label")))
                         .toList()
@@ -68,7 +68,7 @@ public class FilterDrawerComponent extends BaseComponent {
      * @return number of providers shown in the badge
      */
     public int getProviderCount() {
-        return step("Получение значения счётчика брендов", () ->
+        return step("[FilterDrawerComponent] Получение значения счётчика брендов", () ->
                 Integer.parseInt(Objects.requireNonNull(
                         root().locator("div:has(> #brands-label) > .badge").textContent()).trim())
         );
@@ -80,7 +80,7 @@ public class FilterDrawerComponent extends BaseComponent {
      * @return list of category names
      */
     public List<String> getCategoryNames() {
-        return step("Получение списка категорий", () ->
+        return step("[FilterDrawerComponent] Получение списка категорий", () ->
                 root().locator("[aria-labelledby='categories-label']").locator(".tag-group__item").all().stream()
                         .map(tag -> Objects.requireNonNull(tag.getAttribute("aria-label")))
                         .toList()
@@ -93,7 +93,7 @@ public class FilterDrawerComponent extends BaseComponent {
      * @return list of collection names
      */
     public List<String> getCollectionNames() {
-        return step("Получение списка коллекций", () ->
+        return step("[FilterDrawerComponent] Получение списка коллекций", () ->
                 root().locator("[aria-labelledby='collections-label']").locator(".tag-group__item").all().stream()
                         .map(tag -> Objects.requireNonNull(tag.getAttribute("aria-label")))
                         .toList()
@@ -107,7 +107,7 @@ public class FilterDrawerComponent extends BaseComponent {
      * @return current component instance
      */
     public FilterDrawerComponent selectProvider(String providerName) {
-        return step(String.format("Выбор провайдера '%s'", providerName), () -> {
+        return step(String.format("[FilterDrawerComponent] Выбор провайдера '%s'", providerName), () -> {
             root().getByRole(AriaRole.ROW, new Locator.GetByRoleOptions()
                     .setName(providerName)
                     .setExact(true))
@@ -120,7 +120,7 @@ public class FilterDrawerComponent extends BaseComponent {
      * Applies the selected filters by clicking the translated "Show" button.
      */
     public CasinoPage clickShow() {
-        return step("Применение фильтров", () -> {
+        return step("[FilterDrawerComponent] Применение фильтров", () -> {
             showButton.click();
             return casinoPageProvider.getObject();
         });

--- a/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.Objects;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static com.example.testsupport.framework.utils.AllureHelper.step;
@@ -45,6 +47,19 @@ public class FilterDrawerComponent extends BaseComponent {
             assertThat(title).isVisible();
             return this;
         });
+    }
+
+    /**
+     * Returns the list of provider names displayed in the drawer.
+     *
+     * @return list of provider names
+     */
+    public List<String> getProviderNames() {
+        return step("Получение списка провайдеров", () ->
+                root().getByRole(AriaRole.ROW).all().stream()
+                        .map(row -> Objects.requireNonNull(row.getAttribute("aria-label")))
+                        .toList()
+        );
     }
 
     /**

--- a/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
@@ -76,6 +76,19 @@ public class FilterDrawerComponent extends BaseComponent {
     }
 
     /**
+     * Returns the list of collection names displayed in the drawer.
+     *
+     * @return list of collection names
+     */
+    public List<String> getCollectionNames() {
+        return step("Получение списка коллекций", () ->
+                root().locator("[aria-labelledby='collections-label']").locator(".tag-group__item").all().stream()
+                        .map(tag -> Objects.requireNonNull(tag.getAttribute("aria-label")))
+                        .toList()
+        );
+    }
+
+    /**
      * Selects a provider within the drawer by its visible name.
      *
      * @param providerName provider label as displayed in UI

--- a/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/FilterDrawerComponent.java
@@ -70,8 +70,7 @@ public class FilterDrawerComponent extends BaseComponent {
     public int getProviderCount() {
         return step("Получение значения счётчика брендов", () ->
                 Integer.parseInt(Objects.requireNonNull(
-                        root().locator("#brands-label").locator("..")
-                                .locator(".badge").textContent()).trim())
+                        root().locator("div:has(> #brands-label) > .badge").textContent()).trim())
         );
     }
 

--- a/src/test/java/com/example/testsupport/pages/components/HeaderComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/HeaderComponent.java
@@ -31,14 +31,14 @@ public class HeaderComponent extends BaseComponent {
      * Clicks the "Casino" link in the header.
      */
     public void clickCasino() {
-        step("Клик по ссылке 'Казино' в хедере", () -> casinoLink.click());
+        step("[HeaderComponent] Клик по ссылке 'Казино' в хедере", () -> casinoLink.click());
     }
 
     /**
      * Verifies that the logo is visible.
      */
     public void verifyLogoVisible() {
-        step("Проверка видимости логотипа", () -> {
+        step("[HeaderComponent] Проверка видимости логотипа", () -> {
             assertThat(logoLink).isVisible();
         });
     }

--- a/src/test/java/com/example/testsupport/pages/components/NavigationPanelComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/NavigationPanelComponent.java
@@ -29,7 +29,7 @@ public class NavigationPanelComponent extends BaseComponent {
      * @return list of navigation category titles in display order
      */
     public List<String> getTitles() {
-        return step("Получение категорий навигационной панели", () -> {
+        return step("[NavigationPanelComponent] Получение категорий навигационной панели", () -> {
             List<String> titles = root().locator("span.navigationTab__text").allInnerTexts();
             String providers = ls.get("casino.navigation.providers");
             return titles.stream()

--- a/src/test/java/com/example/testsupport/pages/components/TabBarComponent.java
+++ b/src/test/java/com/example/testsupport/pages/components/TabBarComponent.java
@@ -30,14 +30,14 @@ public class TabBarComponent extends BaseComponent {
      * Clicks the "Casino" tab.
      */
     public void clickCasino() {
-        step("Клик по табу 'Казино'", () -> casinoTab.click());
+        step("[TabBarComponent] Клик по табу 'Казино'", () -> casinoTab.click());
     }
 
     /**
      * Opens the user profile.
      */
     public void openProfile() {
-        step("Открытие профиля пользователя", () -> profileTab.click());
+        step("[TabBarComponent] Открытие профиля пользователя", () -> profileTab.click());
     }
 }
 

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -95,6 +95,15 @@ class MultilingualNavigationTest extends BaseTest {
 
             Assertions.assertIterableEquals(apiNavigationCategories, uiNavigationCategories);
         });
+
+        step("Сравниваем бренды из API и фильтров", () -> {
+            List<String> apiBrands = ctx.gamblingBrandsResponse.brandNames();
+            List<String> uiBrands = ctx.casinoPage.openFilters()
+                    .verifyIsLoaded()
+                    .getProviderNames();
+
+            Assertions.assertIterableEquals(apiBrands, uiBrands);
+        });
     }
 }
 

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -83,7 +83,7 @@ class MultilingualNavigationTest extends BaseTest {
         });
 
         step("Сравниваем категории из API и интерфейса", () -> {
-            List<String> apiCategories = ctx.gamblingCategoriesResponse.horizontalCategoryNames(ls);
+            List<String> apiCategories = ctx.gamblingCategoriesResponse.horizontalCategoryNamesWithLobby(ls);
             List<String> uiCategories = ctx.casinoPage.categoryTabs().getTitles();
 
             Assertions.assertIterableEquals(apiCategories, uiCategories);
@@ -97,10 +97,7 @@ class MultilingualNavigationTest extends BaseTest {
         });
 
         step("Сравниваем категории из API и фильтров", () -> {
-            List<String> apiFilterCategories = ctx.gamblingCategoriesResponse.horizontalCategoryNames(ls)
-                    .stream()
-                    .skip(1)
-                    .toList();
+            List<String> apiFilterCategories = ctx.gamblingCategoriesResponse.horizontalCategoryNames();
             List<String> uiFilterCategories = ctx.casinoPage.openFilters()
                     .verifyIsLoaded()
                     .getCategoryNames();

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -96,6 +96,15 @@ class MultilingualNavigationTest extends BaseTest {
             Assertions.assertIterableEquals(apiNavigationCategories, uiNavigationCategories);
         });
 
+        step("Сравниваем категории из API и фильтров", () -> {
+            List<String> apiFilterCategories = ctx.gamblingCategoriesResponse.horizontalCategoryNames();
+            List<String> uiFilterCategories = ctx.casinoPage.openFilters()
+                    .verifyIsLoaded()
+                    .getCategoryNames();
+
+            Assertions.assertIterableEquals(apiFilterCategories, uiFilterCategories);
+        });
+
         step("Сравниваем бренды из API и фильтров", () -> {
             List<String> apiBrands = ctx.gamblingBrandsResponse.brandNames();
             List<String> uiBrands = ctx.casinoPage.openFilters()

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -7,11 +7,11 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.beans.factory.ObjectProvider;
 import com.example.testsupport.pages.CasinoPage;
+import com.example.testsupport.pages.components.FilterDrawerComponent;
 import com.example.testsupport.framework.api.client.FrontApiClient;
 import com.example.testsupport.framework.api.client.params.GamblingBrandsParams;
 import com.example.testsupport.framework.api.client.params.GamblingCategoriesParams;
 import com.example.testsupport.framework.api.client.params.GamblingGamesParams;
-import com.example.testsupport.framework.api.client.params.DeviceType;
 import com.example.testsupport.framework.api.dto.gambling.GamblingBrandsResponse;
 import com.example.testsupport.framework.api.dto.gambling.GamblingCategoriesResponse;
 import com.example.testsupport.framework.api.dto.gambling.GamblingGamesResponse;
@@ -42,6 +42,7 @@ class MultilingualNavigationTest extends BaseTest {
         final class TestContext {
             MainPage mainPage;
             CasinoPage casinoPage;
+            FilterDrawerComponent filterDrawer;
             GamblingCategoriesResponse gamblingCategoriesResponse;
             GamblingGamesResponse gamblingGamesResponse;
             GamblingBrandsResponse gamblingBrandsResponse;
@@ -97,19 +98,18 @@ class MultilingualNavigationTest extends BaseTest {
         });
 
         step("Сравниваем категории из API и фильтров", () -> {
+            ctx.filterDrawer = ctx.casinoPage.openFilters()
+                    .verifyIsLoaded();
+
             List<String> apiFilterCategories = ctx.gamblingCategoriesResponse.horizontalCategoryNames();
-            List<String> uiFilterCategories = ctx.casinoPage.openFilters()
-                    .verifyIsLoaded()
-                    .getCategoryNames();
+            List<String> uiFilterCategories = ctx.filterDrawer.getCategoryNames();
 
             Assertions.assertIterableEquals(apiFilterCategories, uiFilterCategories);
         });
 
         step("Сравниваем бренды из API и фильтров", () -> {
             List<String> apiBrands = ctx.gamblingBrandsResponse.brandNames();
-            List<String> uiBrands = ctx.casinoPage.openFilters()
-                    .verifyIsLoaded()
-                    .getProviderNames();
+            List<String> uiBrands = ctx.filterDrawer.getProviderNames();
 
             Assertions.assertIterableEquals(apiBrands, uiBrands);
         });

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -97,21 +97,28 @@ class MultilingualNavigationTest extends BaseTest {
             Assertions.assertIterableEquals(apiNavigationCategories, uiNavigationCategories);
         });
 
-        step("Сравниваем категории из API и фильтров", () -> {
-            ctx.filterDrawer = ctx.casinoPage.openFilters()
-                    .verifyIsLoaded();
+          step("Сравниваем категории из API и фильтров", () -> {
+              ctx.filterDrawer = ctx.casinoPage.openFilters()
+                      .verifyIsLoaded();
 
-            List<String> apiFilterCategories = ctx.gamblingCategoriesResponse.horizontalCategoryNames();
-            List<String> uiFilterCategories = ctx.filterDrawer.getCategoryNames();
+              List<String> apiFilterCategories = ctx.gamblingCategoriesResponse.horizontalCategoryNames();
+              List<String> uiFilterCategories = ctx.filterDrawer.getCategoryNames();
 
-            Assertions.assertIterableEquals(apiFilterCategories, uiFilterCategories);
-        });
+              Assertions.assertIterableEquals(apiFilterCategories, uiFilterCategories);
+          });
 
-        step("Сравниваем бренды из API и фильтров", () -> {
-            List<String> apiBrands = ctx.gamblingBrandsResponse.brandNames();
-            List<String> uiBrands = ctx.filterDrawer.getProviderNames();
+          step("Сравниваем коллекции из API и фильтров", () -> {
+              List<String> apiCollections = ctx.gamblingCategoriesResponse.verticalCategoryNames();
+              List<String> uiCollections = ctx.filterDrawer.getCollectionNames();
 
-            Assertions.assertIterableEquals(apiBrands, uiBrands);
+              Assertions.assertIterableEquals(apiCollections, uiCollections);
+          });
+
+          step("Сравниваем бренды из API и фильтров", () -> {
+              List<String> apiBrands = ctx.gamblingBrandsResponse.brandNames();
+              List<String> uiBrands = ctx.filterDrawer.getProviderNames();
+
+              Assertions.assertIterableEquals(apiBrands, uiBrands);
         });
     }
 }

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -97,7 +97,10 @@ class MultilingualNavigationTest extends BaseTest {
         });
 
         step("Сравниваем категории из API и фильтров", () -> {
-            List<String> apiFilterCategories = ctx.gamblingCategoriesResponse.horizontalCategoryNames();
+            List<String> apiFilterCategories = ctx.gamblingCategoriesResponse.horizontalCategoryNames(ls)
+                    .stream()
+                    .skip(1)
+                    .toList();
             List<String> uiFilterCategories = ctx.casinoPage.openFilters()
                     .verifyIsLoaded()
                     .getCategoryNames();

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -122,8 +122,8 @@ class MultilingualNavigationTest extends BaseTest {
         });
 
         step("Проверяем счётчик брендов в фильтрах", () -> {
-            int badgeCount = ctx.filterDrawer.getProviderCount();
             int apiCount = ctx.gamblingBrandsResponse.brandNames().size();
+            int badgeCount = ctx.filterDrawer.getProviderCount();
 
             Assertions.assertEquals(apiCount, badgeCount);
         });

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -120,6 +120,13 @@ class MultilingualNavigationTest extends BaseTest {
 
               Assertions.assertIterableEquals(apiBrands, uiBrands);
         });
+
+        step("Проверяем счётчик брендов в фильтрах", () -> {
+            int badgeCount = ctx.filterDrawer.getProviderCount();
+            int apiCount = ctx.gamblingBrandsResponse.brandNames().size();
+
+            Assertions.assertEquals(apiCount, badgeCount);
+        });
     }
 }
 

--- a/src/test/java/tests/MultilingualNavigationTest.java
+++ b/src/test/java/tests/MultilingualNavigationTest.java
@@ -97,7 +97,7 @@ class MultilingualNavigationTest extends BaseTest {
             Assertions.assertIterableEquals(apiNavigationCategories, uiNavigationCategories);
         });
 
-          step("Сравниваем категории из API и фильтров", () -> {
+        step("Сравниваем категории из API и фильтров", () -> {
               ctx.filterDrawer = ctx.casinoPage.openFilters()
                       .verifyIsLoaded();
 
@@ -107,14 +107,14 @@ class MultilingualNavigationTest extends BaseTest {
               Assertions.assertIterableEquals(apiFilterCategories, uiFilterCategories);
           });
 
-          step("Сравниваем коллекции из API и фильтров", () -> {
+        step("Сравниваем коллекции из API и фильтров", () -> {
               List<String> apiCollections = ctx.gamblingCategoriesResponse.verticalCategoryNames();
               List<String> uiCollections = ctx.filterDrawer.getCollectionNames();
 
               Assertions.assertIterableEquals(apiCollections, uiCollections);
           });
 
-          step("Сравниваем бренды из API и фильтров", () -> {
+        step("Сравниваем бренды из API и фильтров", () -> {
               List<String> apiBrands = ctx.gamblingBrandsResponse.brandNames();
               List<String> uiBrands = ctx.filterDrawer.getProviderNames();
 


### PR DESCRIPTION
## Summary
- collect provider names from casino filter drawer and compare with API brands
- expose brand names from GamblingBrandsResponse

## Testing
- `gradle test` *(fails: Failed to download Chromium for Playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68bf35cc6c24832f99c4f325d63b2788